### PR TITLE
Refactor styletron output and hydration strategy

### DIFF
--- a/packages/react-demo-compat/src/app/index.js
+++ b/packages/react-demo-compat/src/app/index.js
@@ -18,7 +18,7 @@ class App extends React.Component {
     }
   }
   logRules() {
-    console.log(document.querySelector('style').sheet.cssRules);
+    console.log(document.querySelector('.styletron').sheet.cssRules);
   }
   render() {
     return (

--- a/packages/react-demo-compat/src/client.js
+++ b/packages/react-demo-compat/src/client.js
@@ -5,7 +5,7 @@ const StyletronClient = require('styletron-client');
 const {StyletronProvider} = require('styletron-react');
 const App = require('./app');
 
-const styletron = new StyletronClient(document.getElementById('styletron'));
+const styletron = new StyletronClient(document.getElementsByClassName('styletron'));
 ReactDOM.render(
   createElement(StyletronProvider, {styletron}, createElement(App, {
     path: window.location.pathname

--- a/packages/react-demo-compat/src/server.js
+++ b/packages/react-demo-compat/src/server.js
@@ -16,7 +16,7 @@ const server = connect();
 server.use(compression());
 server.use(serve('static', {index: false}));
 
-const getMarkup = (bodyContent, cssContent, count, legacyCss, hydrationSrc) =>
+const getMarkup = (bodyContent, cssContent, legacyCss, hydrationSrc) =>
 `<!DOCTYPE html>
 <html>
 <head>
@@ -24,7 +24,7 @@ const getMarkup = (bodyContent, cssContent, count, legacyCss, hydrationSrc) =>
 <title>Styletron React Demo</title>
 <link rel="icon" href="data:;base64,iVBORw0KGgo=">
 <style data-styletron>${legacyCss}</style>
-<style id="styletron" data-count="${count}"">${cssContent}</style>
+${cssContent}
 </head>
 <body>
 <div id="app">${bodyContent}</div>
@@ -42,11 +42,10 @@ server.use((req, res) => {
     return renderToString(app);
   });
   
-  const modernCss = styletron.getCss();
-  const count = styletron.getInjectionCount();
+  const modernCss = styletron.getStylesheetsHtml();
   const hydrationSrc = generateHydrationScriptSrc(injectedKeys);
 
-  res.end(getMarkup(html, modernCss, count, css, hydrationSrc));
+  res.end(getMarkup(html, modernCss, css, hydrationSrc));
 });
 
 http.createServer(server).listen(3000, () => {

--- a/packages/react-demo/src/app/index.js
+++ b/packages/react-demo/src/app/index.js
@@ -17,7 +17,7 @@ class App extends React.Component {
     }
   }
   logRules() {
-    console.log(document.querySelector('style').sheet.cssRules);
+    console.log(document.querySelector('.styletron').sheet.cssRules);
   }
   render() {
     return (

--- a/packages/react-demo/src/client.js
+++ b/packages/react-demo/src/client.js
@@ -5,7 +5,7 @@ const StyletronClient = require('styletron-client');
 const {StyletronProvider} = require('styletron-react');
 const App = require('./app');
 
-const styletron = new StyletronClient(document.getElementById('styletron'));
+const styletron = new StyletronClient(document.getElementsByClassName('styletron'));
 ReactDOM.render(
   createElement(StyletronProvider, {styletron}, createElement(App, {
     path: window.location.pathname

--- a/packages/react-demo/src/server.js
+++ b/packages/react-demo/src/server.js
@@ -13,14 +13,14 @@ const server = connect();
 server.use(compression());
 server.use(serve('static', {index: false}));
 
-const getMarkup = (bodyContent, cssContent, count) =>
+const getMarkup = (bodyContent, cssContent) =>
 `<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
 <title>Styletron React Demo</title>
 <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-<style id="styletron" data-count="${count}"">${cssContent}</style>
+${cssContent}
 </head>
 <body>
 <div id="app">${bodyContent}</div>
@@ -34,9 +34,8 @@ server.use((req, res) => {
     path: req.url
   }));
   const html = renderToString(app);
-  const css = styletron.getCss();
-  const count = styletron.getInjectionCount();
-  res.end(getMarkup(html, css, count));
+  const css = styletron.getStylesheetsHtml();
+  res.end(getMarkup(html, css));
 });
 
 http.createServer(server).listen(3000, () => {

--- a/packages/styletron-client/package.json
+++ b/packages/styletron-client/package.json
@@ -13,7 +13,6 @@
     "test": "unitest --browser=lib/test/browser.js"
   },
   "dependencies": {
-    "fenwick-tree": "0.0.0",
     "styletron-core": "^2.0.0-beta.1"
   },
   "devDependencies": {

--- a/packages/styletron-client/src/styletron-client.js
+++ b/packages/styletron-client/src/styletron-client.js
@@ -105,5 +105,4 @@ function declarationToRule(className, {prop, val, pseudo}) {
     selector += pseudo;
   }
   return `${selector}{${decl}}`;
-  // return media ? `@media ${media}{${rule}}` : rule;
 }

--- a/packages/styletron-client/src/test/browser.js
+++ b/packages/styletron-client/src/test/browser.js
@@ -3,7 +3,6 @@ const test = require('tape');
 const util = require('util');
 const fs = require('fs');
 const path = require('path');
-const fenwick = require('fenwick-tree');
 const forEach = Array.prototype.forEach;
 
 const fixtures = require('test-fixtures');
@@ -15,45 +14,32 @@ class StyletronTest extends Styletron {
   getCache() {
     return this.cache;
   }
-  getCounts() {
-    return this.counts;
+  getMediaSheets() {
+    return this.mediaSheets;
+  }
+  getuniqueCount() {
+    return this.uniqueCount;
   }
 }
 
 test('hydration basic', t => {
-  const element = createStyleElement(fixtures.basic.css);
-  const instance = new StyletronTest(element);
-  t.deepEqual(instance.getCache(), fixtures.basic.cache);
-  let counts = instance.getCounts();
-  t.equal(fenwick.query(counts, 0), 3);
-  t.equal(fenwick.query(counts, 1), 4);
-  instance.injectDeclaration({prop: 'color', val: 'purple', media: '(max-width: 800px)'});
-  t.equal(fenwick.query(counts, 0), 3);
-  t.equal(fenwick.query(counts, 1), 5);
-  t.end();
-});
-
-test('deterministic server call count hydration', t => {
-  const element = createStyleElement('');
-  element.setAttribute('data-count', '6');
-  const instance = new StyletronTest(element);
-  const decls = [
-    {prop: 'color', val: 'red'},
-    {prop: 'color', val: 'blue'},
-    {prop: 'color', val: 'blue', media: '(max-width: 333px)'},
-    {prop: 'color', val: 'green'},
-    {prop: 'color', val: 'red', media: 'screen and (max-width: 400px)'},
-    {prop: 'color', val: 'purple'}
-  ];
-  decls.forEach(decl => instance.injectDeclaration(decl));
-  t.equal(element.sheet.rules.length, 0, 'no rules added');
-  t.deepEqual(instance.getCache(), fixtures.simple.cache, 'cache still hydrated');
+  const elements = createFixtures([{
+    css: '.c4:hover{display:none}.c0{color:red}.c1{color:green}',
+  }, {
+    media: '(max-width: 800px)',
+    css: '.c3:hover{color:green}.c2{color:green}'
+  }]);
+  const instance = new StyletronTest(elements);
+  t.deepEqual(instance.getCache(), fixtures.basic.cache, 'cache hydrated');
+  t.equal(instance.getuniqueCount(), 5, 'count correctly hyrdated');
+  const newClass = instance.injectDeclaration({prop: 'color', val: 'purple', media: '(max-width: 800px)'});
+  t.equal(newClass, 'c5', 'new class with correct count');
   t.end();
 });
 
 test('rule insertion order', t => {
   const element = createStyleElement('');
-  const instance = new StyletronTest(element);
+  const instance = new StyletronTest([element]);
   const decls = [
     {prop: 'color', val: 'red'},
     {prop: 'color', val: 'blue'},
@@ -63,24 +49,47 @@ test('rule insertion order', t => {
     {prop: 'color', val: 'purple'}
   ];
   decls.forEach(decl => instance.injectDeclaration(decl));
-  t.equal(element.sheet.rules.length, 6);
-  const expected = [
+  t.equal(element.sheet.rules.length, 4);
+  const mainExpected = [
     '.c0 { color: red; }',
     '.c1 { color: blue; }',
     '.c3 { color: green; }',
     '.c5 { color: purple; }',
-    '@media (max-width: 333px) { \n  .c2 { color: blue; }\n}',
-    '@media screen and (max-width: 400px) { \n  .c4 { color: red; }\n}'
   ];
+  const mediaExpected = {
+    '(max-width: 333px)': [
+      '.c2 { color: blue; }'
+    ],
+    'screen and (max-width: 400px)': [
+      '.c4 { color: red; }'
+    ]
+  };
   forEach.call(element.sheet.rules, (rule, i) => {
-    t.equal(rule.cssText, expected[i]);
+    t.equal(rule.cssText, mainExpected[i]);
+  });
+  const mediaSheets = instance.getMediaSheets();
+  t.deepEqual(Object.keys(mediaSheets), [
+    '(max-width: 333px)',
+    'screen and (max-width: 400px)'
+  ]);
+  Object.keys(mediaExpected).forEach(mediaKey => {
+    forEach.call(mediaSheets[mediaKey].sheet.rules, (rule, i) => {
+      t.equal(rule.cssText, mediaExpected[mediaKey][i], 'media decl matches');
+    });
   });
   t.end();
 });
 
-function createStyleElement(css) {
+function createFixtures(sheets) {
+  return sheets.map(sheet => createStyleElement(sheet.css, sheet.media));
+}
+
+function createStyleElement(css, media) {
   const element = document.createElement('style');
   element.appendChild(document.createTextNode(css));
+  if (media) {
+    element.setAttribute('media', media);
+  }
   document.body.appendChild(element);
   return element;
 }

--- a/packages/styletron-client/src/test/browser.js
+++ b/packages/styletron-client/src/test/browser.js
@@ -17,7 +17,7 @@ class StyletronTest extends Styletron {
   getMediaSheets() {
     return this.mediaSheets;
   }
-  getuniqueCount() {
+  getUniqueDeclarationCount() {
     return this.uniqueCount;
   }
 }
@@ -31,7 +31,7 @@ test('hydration basic', t => {
   }]);
   const instance = new StyletronTest(elements);
   t.deepEqual(instance.getCache(), fixtures.basic.cache, 'cache hydrated');
-  t.equal(instance.getuniqueCount(), 5, 'count correctly hyrdated');
+  t.equal(instance.getUniqueDeclarationCount(), 5, 'count correctly hyrdated');
   const newClass = instance.injectDeclaration({prop: 'color', val: 'purple', media: '(max-width: 800px)'});
   t.equal(newClass, 'c5', 'new class with correct count');
   t.end();

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -12,7 +12,7 @@ class StyletronCore {
       media: {},
       pseudo: {}
     };
-    this.counter = 0;
+    this.uniqueCount = 0;
   }
 
   static assignDecl(target, decl, className) {
@@ -52,8 +52,8 @@ class StyletronCore {
     if (cached) {
       return cached;
     }
-    const className = `c${this.counter.toString(36)}`;
-    this.counter++;
+    const className = `c${this.uniqueCount.toString(36)}`;
+    this.uniqueCount++;
     StyletronCore.assignDecl(this.cache, decl, className);
     return className;
   }

--- a/packages/styletron-core/src/test/index.js
+++ b/packages/styletron-core/src/test/index.js
@@ -12,14 +12,22 @@ class StyletronTest extends Styletron {
     return this.cache;
   }
 
+  getCount() {
+    return this.uniqueCount;
+  }
+
 }
 
 test('test injection', t => {
   const instance = new StyletronTest();
+  t.equal(instance.getCount(), 0, 'starts with 0 declarations');
   const decl1 = {prop: 'color', val: 'red'};
   instance.injectDeclaration(decl1);
   t.equal(instance.getCache().color.red, 'c0');
   t.equal(instance.getCachedDeclaration(decl1), 'c0');
+  t.equal(instance.getCount(), 1, 'unique count incremented');
+  instance.injectDeclaration(decl1);
+  t.equal(instance.getCount(), 1, 'unique count not incremented after repeat injection');
   instance.injectDeclaration({prop: 'color', val: 'green'});
   t.equal(instance.getCache().color.green, 'c1');
   instance.injectDeclaration({prop: 'color', val: 'green', media: '(max-width: 800px)'});
@@ -28,5 +36,6 @@ test('test injection', t => {
   t.equal(instance.getCache().media['(max-width: 800px)'].pseudo[':hover'].color.green, 'c3');
   instance.injectDeclaration({prop: 'display', val: 'none', pseudo: ':hover'});
   t.equal(instance.getCache().pseudo[':hover'].display.none, 'c4');
+  t.equal(instance.getCount(), 5, 'ends with 4 unique declarations');
   t.end();
 });

--- a/packages/styletron-server/src/base-obj-to-css.js
+++ b/packages/styletron-server/src/base-obj-to-css.js
@@ -1,0 +1,31 @@
+module.exports = baseHandler;
+
+function baseHandler(key, valueObj) {
+  return key === 'pseudo' ?
+    pseudoObjToCss(valueObj) : valsObjToCss(key, valueObj);
+}
+
+function pseudoObjToCss(pseudoObj) {
+  let css = '';
+  for (let pseudoClass in pseudoObj) {
+    const propsObj = pseudoObj[pseudoClass];
+    for (let prop in propsObj) {
+      css += valsObjToCss(prop, propsObj[prop], pseudoClass);
+    }
+  }
+  return css;
+}
+
+function valsObjToCss(prop, valsObj, pseudo) {
+  let css = '';
+  for (let val in valsObj) {
+    const className = valsObj[val];
+    css += declToCss(prop, val, className, pseudo);
+  }
+  return css;
+}
+
+function declToCss(prop, val, className, pseudo) {
+  const classString = pseudo ? `${className}${pseudo}` : className;
+  return `.${classString}{${prop}:${val}}`;
+}

--- a/packages/styletron-server/src/cache-to-css.js
+++ b/packages/styletron-server/src/cache-to-css.js
@@ -1,3 +1,5 @@
+const baseHandler = require('./base-obj-to-css');
+
 module.exports = cacheObjToCss;
 
 /*
@@ -29,34 +31,4 @@ function mediaObjToCss(mediaObj) {
     css += `@media ${query}{${mediaCss}}`;
   }
   return css;
-}
-
-function baseHandler(key, valueObj) {
-  return key === 'pseudo' ?
-    pseudoObjToCss(valueObj) : valsObjToCss(key, valueObj);
-}
-
-function pseudoObjToCss(pseudoObj) {
-  let css = '';
-  for (let pseudoClass in pseudoObj) {
-    const propsObj = pseudoObj[pseudoClass];
-    for (let prop in propsObj) {
-      css += valsObjToCss(prop, propsObj[prop], pseudoClass);
-    }
-  }
-  return css;
-}
-
-function valsObjToCss(prop, valsObj, pseudo) {
-  let css = '';
-  for (let val in valsObj) {
-    const className = valsObj[val];
-    css += declToCss(prop, val, className, pseudo);
-  }
-  return css;
-}
-
-function declToCss(prop, val, className, pseudo) {
-  const classString = pseudo ? `${className}${pseudo}` : className;
-  return `.${classString}{${prop}:${val}}`;
 }

--- a/packages/styletron-server/src/cache-to-stylesheets.js
+++ b/packages/styletron-server/src/cache-to-stylesheets.js
@@ -1,0 +1,40 @@
+const baseHandler = require('./base-obj-to-css');
+
+module.exports = cacheToStylesheets;
+
+/*
+ * Converts cache object to a CSS string
+ * @param  {object} cacheObj Cache object
+ * @return {string}          String of CSS
+ */
+function cacheToStylesheets(cacheObj) {
+  let mediaSheets;
+  let mainCss = '';
+  for (let key in cacheObj) {
+    if (key === 'media') {
+      mediaSheets = getMediaSheets(cacheObj[key]);
+      continue;
+    }
+    mainCss += baseHandler(key, cacheObj[key]);
+  }
+  const mainSheet = {
+    css: mainCss
+  };
+  return mediaSheets ? [mainSheet].concat(mediaSheets) : [mainSheet];
+}
+
+function getMediaSheets(mediaObj) {
+  const stylesheets = [];
+  for (let query in mediaObj) {
+    const obj = mediaObj[query];
+    let mediaCss = '';
+    for (let key in obj) {
+      mediaCss += baseHandler(key, obj[key]);
+    }
+    stylesheets.push({
+      media: query,
+      css: mediaCss
+    });
+  }
+  return stylesheets;
+}

--- a/packages/styletron-server/src/generate-html-string.js
+++ b/packages/styletron-server/src/generate-html-string.js
@@ -1,0 +1,11 @@
+module.exports = generateHtmlString;
+
+function generateHtmlString(sheets) {
+  let html = '';
+  for (let i = 0; i < sheets.length; i++) {
+    const sheet = sheets[i];
+    const mediaAttr = sheet.media ? ` media="${sheet.media}"` : '';
+    html += `<style class="styletron"${mediaAttr}>${sheet.css}</style>`;
+  }
+  return html;
+}

--- a/packages/styletron-server/src/generate-html-string.js
+++ b/packages/styletron-server/src/generate-html-string.js
@@ -1,11 +1,11 @@
 module.exports = generateHtmlString;
 
-function generateHtmlString(sheets) {
+function generateHtmlString(sheets, className) {
   let html = '';
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
     const mediaAttr = sheet.media ? ` media="${sheet.media}"` : '';
-    html += `<style class="styletron"${mediaAttr}>${sheet.css}</style>`;
+    html += `<style class="${className}"${mediaAttr}>${sheet.css}</style>`;
   }
   return html;
 }

--- a/packages/styletron-server/src/styletron-server.js
+++ b/packages/styletron-server/src/styletron-server.js
@@ -1,4 +1,5 @@
 const cacheToCss = require('./cache-to-css');
+const cacheToStylesheets = require('./cache-to-stylesheets');
 const StyletronCore = require('styletron-core');
 
 /**
@@ -18,6 +19,10 @@ class StyletronServer extends StyletronCore {
   injectDeclaration(decl) {
     this.injectionCount++;
     return super.injectDeclaration(decl);
+  }
+
+  getStylesheets() {
+    return cacheToStylesheets(this.cache);
   }
 
   /**

--- a/packages/styletron-server/src/styletron-server.js
+++ b/packages/styletron-server/src/styletron-server.js
@@ -1,5 +1,6 @@
 const cacheToCss = require('./cache-to-css');
 const cacheToStylesheets = require('./cache-to-stylesheets');
+const generateHtmlString = require('./generate-html-string');
 const StyletronCore = require('styletron-core');
 
 /**
@@ -23,6 +24,10 @@ class StyletronServer extends StyletronCore {
 
   getStylesheets() {
     return cacheToStylesheets(this.cache);
+  }
+
+  getStylesheetsHtml() {
+    return generateHtmlString(this.getStylesheets());
   }
 
   /**

--- a/packages/styletron-server/src/styletron-server.js
+++ b/packages/styletron-server/src/styletron-server.js
@@ -14,7 +14,7 @@ class StyletronServer extends StyletronCore {
    */
   constructor() {
     super();
-    this.injectionCount = 0;
+    this.injectionCallCount = 0;
   }
 
   injectDeclaration(decl) {
@@ -45,8 +45,8 @@ class StyletronServer extends StyletronCore {
     return cacheToCss(this.cache);
   }
 
-  getInjectionCount() {
-    return this.injectionCount;
+  getInjectionCallCount() {
+    return this.injectionCallCount;
   }
 
 }

--- a/packages/styletron-server/src/styletron-server.js
+++ b/packages/styletron-server/src/styletron-server.js
@@ -26,8 +26,8 @@ class StyletronServer extends StyletronCore {
     return cacheToStylesheets(this.cache);
   }
 
-  getStylesheetsHtml() {
-    return generateHtmlString(this.getStylesheets());
+  getStylesheetsHtml(className = 'styletron') {
+    return generateHtmlString(this.getStylesheets(), className);
   }
 
   /**

--- a/packages/styletron-server/src/test/index.js
+++ b/packages/styletron-server/src/test/index.js
@@ -43,3 +43,10 @@ test('test getStylesheets method', t => {
   ]);
   t.end();
 });
+
+test('test getStylesheetsHtml method', t => {
+  const instance = new StyletronTest();
+  instance.setCache(fixtures.basic.cache);
+  t.equal(instance.getStylesheetsHtml(), '<style class="styletron">.c4:hover{display:none}.c0{color:red}.c1{color:green}</style><style class="styletron" media="(max-width: 800px)">.c3:hover{color:green}.c2{color:green}</style>');
+  t.end();
+});

--- a/packages/styletron-server/src/test/index.js
+++ b/packages/styletron-server/src/test/index.js
@@ -22,9 +22,24 @@ test('test toCss', t => {
   t.end();
 });
 
-test('test toCss method', t => {
+test('test getCss method', t => {
   const instance = new StyletronTest();
   instance.setCache(fixtures.basic.cache);
   t.equal(instance.getCss(), fixtures.basic.css);
+  t.end();
+});
+
+test('test getStylesheets method', t => {
+  const instance = new StyletronTest();
+  instance.setCache(fixtures.basic.cache);
+  t.deepEqual(instance.getStylesheets(), [
+    {
+      css: '.c4:hover{display:none}.c0{color:red}.c1{color:green}'
+    },
+    {
+      media: '(max-width: 800px)',
+      css: '.c3:hover{color:green}.c2{color:green}'
+    }
+  ]);
   t.end();
 });


### PR DESCRIPTION
- Implement simple parse of actual CSS to solve https://github.com/rtsao/styletron/issues/4
- Output a separate stylesheet for each media query. This simplifies server stringification and client parse logic. It also moves us closer to solving https://github.com/rtsao/styletron/issues/7
- Remove deterministic injection counting hydration strategy for now until we have a chance to do more testing/benchmarking in production