### PR TITLE
StyletronCore constructor defaults and docs

### DIFF
--- a/packages/styletron-client/src/styletron-client.js
+++ b/packages/styletron-client/src/styletron-client.js
@@ -14,6 +14,7 @@ class StyletronClient extends StyletronCore {
   /**
    * Create a new StyletronClient instance
    * @param {NodeList|HTMLCollection|HTMLStyleElement[]} serverStyles - List of server style elements
+   * @param {object} [opts] - StyletronCore options
    */
   constructor(serverStyles, opts) {
     super(opts);

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -6,8 +6,8 @@ class StyletronCore {
 
   /**
    * Create a new StyletronCore instance
-   * @param {object} [options]           An object containing options
-   * @param {string} [options.prefix=''] A prefix for generated CSS class names
+   * @param {object} [opts]           An object containing options
+   * @param {string} [opts.prefix=''] A prefix for generated CSS class names
    */
   constructor({prefix = ''} = {}) {
     this.cache = {

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -6,13 +6,15 @@ class StyletronCore {
 
   /**
    * Create a new StyletronCore instance
+   * @param {object} [options]           An object containing options
+   * @param {string} [options.prefix=''] A prefix for generated CSS class names
    */
-  constructor({prefix = false} = {}) {
+  constructor({prefix = ''} = {}) {
     this.cache = {
       media: {},
       pseudo: {}
     };
-    this.prefix = prefix;
+    this.prefix = prefix === '' ? false : prefix;
     this.uniqueCount = 0;
     this.offset = 10; // skip 0-9
     this.msb = 35;

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -7,7 +7,7 @@ class StyletronCore {
   /**
    * Create a new StyletronCore instance
    */
-  constructor({prefix = false} = {prefix: false}) {
+  constructor({prefix = false} = {}) {
     this.cache = {
       media: {},
       pseudo: {}

--- a/packages/styletron-core/src/test/index.js
+++ b/packages/styletron-core/src/test/index.js
@@ -38,3 +38,21 @@ test('test injection', t => {
   t.equal(instance.getCount(), 5, 'ends with 4 unique declarations');
   t.end();
 });
+
+test('test constructor', t => {
+  const instance = new Styletron();
+  t.equal(instance.prefix, false, 'prefix defaults to false');
+  t.end();
+});
+
+test('test injection with prefix', t => {
+  const instance = new StyletronTest({prefix: 'qq'});
+  t.equal(instance.prefix, 'qq', 'prefix is set on instance');
+  t.equal(instance.getCount(), 0, 'starts with 0 declarations');
+  const decl1 = {prop: 'color', val: 'red'};
+  instance.injectDeclaration(decl1);
+  t.equal(instance.getCache().color.red, 'qqa');
+  t.equal(instance.getCachedDeclaration(decl1), 'qqa');
+  t.equal(instance.getCount(), 1, 'unique count incremented');
+  t.end();
+});


### PR DESCRIPTION
I did not update the docs for `StyletronServer` because its method signature is identical to that of `StyletronCore` (and it is already documented as extending `StyletronCore`).