### PR TITLE
Added support for build htmldocs on windows environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-docs": "jsdoc -c jsdoc.json",
     "pretest": "npm run lint && lerna run pretest",
     "test": "lerna run test --concurrency=1",
-    "predeploy-docs": "rm -rf htmldocs && npm run build-docs && echo styletron.js.org > htmldocs/CNAME",
+    "predeploy-docs": "rimraf htmldocs && npm run build-docs && echo styletron.js.org > htmldocs/CNAME",
     "deploy-docs": "push-dir --dir htmldocs --branch gh-pages"
   },
   "dependencies": {},
@@ -27,6 +27,7 @@
     "react": "^15.3.0",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
+    "rimraf": "^2.5.4",
     "tape": "^4.6.0",
     "unitest": "^0.14.2"
   },


### PR DESCRIPTION
Hi @rtsao

I had a problem recently on the support for windows environment. The build task of the [Milligram](https://github.com/milligram/milligram/issues/122) was not working on Windows. I solved this problem using this CLI.

Tomorrow in my free time I will submitted a full coverage to the windows environment using AppVeyor to automate this verification process. For more information click [here](https://en.wikipedia.org/wiki/AppVeyor).

Hope you're having a great day!