### PR TITLE
Fix for chrome CSSOM bug

### DIFF
--- a/packages/styletron-client/src/styletron-client.js
+++ b/packages/styletron-client/src/styletron-client.js
@@ -88,7 +88,11 @@ class StyletronClient extends StyletronCore {
       } else {
         sheet = this.mainSheet.sheet;
       }
-      sheet.insertRule(rule, sheet.cssRules.length);
+      if (sheet.styleSheet) {
+        sheet.styleSheet.cssText += rule;
+      } else {
+        sheet.appendChild(document.createTextNode(rule));
+      }
     }
     return className;
   }


### PR DESCRIPTION
Using the `appendChild` instead of `insertRule` fixes the chrome bug at least.
Were you using `insertRule` for performance reasons @rtsao ?