### PR TITLE
Add support for cssFloat

### DIFF
--- a/packages/styletron-utils/src/hyphenate-style-name.js
+++ b/packages/styletron-utils/src/hyphenate-style-name.js
@@ -5,6 +5,7 @@ module.exports = hyphenateStyleName;
 
 function hyphenateStyleName(prop) {
   return prop
+    .replace('cssFloat', 'float')
     .replace(uppercasePattern, '-$&')
     .toLowerCase()
     .replace(msPattern, '-ms-');


### PR DESCRIPTION
When using `postcss-js` it transforms `float` to `cssFloat`, currently styletron doesn't handle that.