### PR TITLE
Added hyphenateStyleName memoization

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,7 +178,7 @@ module.exports = {
         "no-restricted-modules": "error",
         "no-restricted-properties": "error",
         "no-restricted-syntax": "error",
-        "no-return-assign": "error",
+        "no-return-assign": "off",
         "no-script-url": "error",
         "no-self-compare": "error",
         "no-sequences": "error",

--- a/packages/styletron-utils/src/hyphenate-style-name.js
+++ b/packages/styletron-utils/src/hyphenate-style-name.js
@@ -1,11 +1,14 @@
 const uppercasePattern = /[A-Z]/g;
 const msPattern = /^ms-/;
+const cache = {};
 
 module.exports = hyphenateStyleName;
 
 function hyphenateStyleName(prop) {
-  return prop
-    .replace(uppercasePattern, '-$&')
-    .toLowerCase()
-    .replace(msPattern, '-ms-');
+  return prop in cache
+    ? cache[prop]
+    : cache[prop] = prop
+      .replace(uppercasePattern, '-$&')
+      .toLowerCase()
+      .replace(msPattern, '-ms-');
 }


### PR DESCRIPTION
This results in a significant speed boost. Also, according to http://cssstats.com/ most sites only use 100-200 different CSS properties so the cache shouldn't get too large. If need be, we can explore using a lightweight LRU.