### PR TITLE
Remove leading spaces in injectStyle

### DIFF
--- a/packages/styletron-react/src/test/browser.js
+++ b/packages/styletron-react/src/test/browser.js
@@ -45,7 +45,7 @@ test('styled applies styles', t => {
       React.createElement(Widget))
   );
   const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
-  t.equal(div.className, ' a', 'styletron classes');
+  t.equal(div.className, 'a', 'styletron classes');
   t.equal(styletron.getCss(), '.a{color:red}');
   t.end();
 });
@@ -58,7 +58,7 @@ test('styled applies static styles', t => {
       React.createElement(Widget))
   );
   const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
-  t.equal(div.className, ' a', 'matches expected styletron classes');
+  t.equal(div.className, 'a', 'matches expected styletron classes');
   t.equal(styletron.getCss(), '.a{color:red}');
   t.end();
 });
@@ -86,14 +86,14 @@ test('styled composition', t => {
       React.createElement(SuperWidget))
   );
   const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
-  t.equal(div.className, ' a b c', 'matches expected styletron classes');
+  t.equal(div.className, 'a b c', 'matches expected styletron classes');
   t.equal(styletron.getCss(), '.a{color:red}.b{display:block}.c{background:black}');
   t.end();
 });
 
 test('innerRef works', t => {
   t.plan(1);
-  
+
   const Widget = styled('button', {color: 'red'});
   const styletron = new Styletron();
 

--- a/packages/styletron-utils/src/inject-style-prefixed.js
+++ b/packages/styletron-utils/src/inject-style-prefixed.js
@@ -39,31 +39,32 @@ function injectStyle(styletron, styles, media, pseudo) {
         const properties = prefixProperties[prefix];
         if (properties[key]) {
           const prefixedPropName = prefix + capitalizeString(key);
-          classString += injectWithPlugins(styletron, prefixedPropName, val, media, pseudo);
+          classString += ' ' + injectWithPlugins(styletron, prefixedPropName, val, media, pseudo);
         }
       }
       // handle un-prefixed
-      classString += injectWithPlugins(styletron, key, val, media, pseudo);
+      classString += ' ' + injectWithPlugins(styletron, key, val, media, pseudo);
       continue;
     }
     if (Array.isArray(val)) {
       for (let i = 0; i < val.length; i++) {
-        classString += injectWithPlugins(styletron, key, val[i], media, pseudo);
+        classString += ' ' + injectWithPlugins(styletron, key, val[i], media, pseudo);
       }
       continue;
     }
     if (valType === 'object') {
       if (key[0] === ':') {
-        classString += injectStyle(styletron, val, media, key);
+        classString += ' ' + injectStyle(styletron, val, media, key);
         continue;
       }
       if (key.substring(0, 6) === '@media') {
-        classString += injectStyle(styletron, val, key.substr(7), pseudo);
+        classString += ' ' + injectStyle(styletron, val, key.substr(7), pseudo);
         continue;
       }
     }
   }
-  return classString;
+  // remove leading space on way out
+  return classString.slice(1);
 }
 
 function injectWithPlugins(styletron, prop, val, media, pseudo) {
@@ -91,5 +92,6 @@ function injectWithPlugins(styletron, prop, val, media, pseudo) {
   }
   // inject original last
   classString += ' ' + styletron.injectDeclaration({prop: baseHyphenated, val, media, pseudo});
-  return classString;
+  // remove leading space on way out
+  return classString.slice(1);
 }

--- a/packages/styletron-utils/src/inject-style.js
+++ b/packages/styletron-utils/src/inject-style.js
@@ -20,14 +20,15 @@ function injectStyle(styletron, styles, media, pseudo) {
     }
     if (valType === 'object') {
       if (key[0] === ':') {
-        classString += injectStyle(styletron, val, media, key);
+        classString += ' ' + injectStyle(styletron, val, media, key);
         continue;
       }
       if (key.substring(0, 6) === '@media') {
-        classString += injectStyle(styletron, val, key.substr(7), pseudo);
+        classString += ' ' + injectStyle(styletron, val, key.substr(7), pseudo);
         continue;
       }
     }
   }
-  return classString;
+  // remove leading space on way out
+  return classString.slice(1);
 }

--- a/packages/styletron-utils/src/test/index.js
+++ b/packages/styletron-utils/src/test/index.js
@@ -20,7 +20,7 @@ test('test injection', t => {
       background: 'orange'
     }
   });
-  t.equal(classString, ' 1 2 3 4');
+  t.equal(classString, '1 2 3 4');
   t.deepEqual(decls, [
     {prop: 'color', val: 'red', media: undefined, pseudo: undefined},
     {prop: 'background-color', val: 'blue', media: undefined, pseudo: undefined},
@@ -47,7 +47,7 @@ test('test injection array', function (t) {
       color: ['green', 'yellow']
     }
   });
-  t.equal(classString, ' 1 2 3 4 5 6');
+  t.equal(classString, '1 2 3 4 5 6');
   t.deepEqual(decls, [
     {prop: 'color', val: 'red', media: undefined, pseudo: undefined},
     {prop: 'color', val: 'blue', media: undefined, pseudo: undefined},
@@ -72,7 +72,7 @@ test('test injection prefixed', function (t) {
     height: ['min-content', 'calc(50%)'],
     boxSizing: 'border-box'
   });
-  t.equal(classString, ' 1 2 3 4 5 6 7 8 9 10 11');
+  t.equal(classString, '1 2 3 4 5 6 7 8 9 10 11');
   t.deepEqual(decls, [
     {prop: 'width', val: '-webkit-calc(100%)', media: undefined, pseudo: undefined},
     {prop: 'width', val: '-moz-calc(100%)', media: undefined, pseudo: undefined},


### PR DESCRIPTION
`join` is too slow, conditionals add way too many extra cycles, etc...

I think your best bet is to get rid of that pesky space when returning the class name. `slice` would seem the most performant option here (`substring`, `subset`, and `RegExp/replace`) don't quite do the trick).

<details>
<summary>Benchmarks</summary>

    Running simple test.

    aphrodite length 582.
    aphrodite-no-important length 472
    cssobj length 641
    cxs length 552
    cxs-optimized length 634
    fela length 421
    free-style length 521
    glamor length 591
    j2c length 748
    jss length 636
    jss-without-preset length 636
    styletron length 500

    Smallest is: fela


      aphrodite              x  13,008 ops/sec ±1.34% (87 runs sampled)
      aphrodite-no-important x  14,508 ops/sec ±1.60% (89 runs sampled)
      cssobj                 x  11,266 ops/sec ±2.47% (88 runs sampled)
      cxs                    x  23,216 ops/sec ±1.20% (83 runs sampled)
      cxs-optimized          x  16,561 ops/sec ±1.17% (85 runs sampled)
      fela                   x  80,517 ops/sec ±1.33% (87 runs sampled)
      free-style             x  22,685 ops/sec ±1.83% (86 runs sampled)
      glamor                 x   8,535 ops/sec ±1.49% (88 runs sampled)
      j2c                    x  38,678 ops/sec ±1.49% (88 runs sampled)
      jss                    x  23,123 ops/sec ±1.28% (87 runs sampled)
      jss-without-preset     x  30,940 ops/sec ±2.10% (84 runs sampled)
      styletron              x 124,100 ops/sec ±1.47% (87 runs sampled)

    Fastest is: styletron


    Running nested test.

    aphrodite length 1179
    aphrodite-no-important length 926
    cssobj length 1111
    cxs length 975
    cxs-optimized length 1061
    fela length 800
    free-style length 802
    glamor length 1479
    j2c length 1339
    jss length 1089
    jss-without-preset length 1089
    styletron length 781

    Smallest is: styletron


      aphrodite              x  5,112 ops/sec ±2.64% (81 runs sampled)
      aphrodite-no-important x  5,297 ops/sec ±2.18% (77 runs sampled)
      cssobj                 x  4,646 ops/sec ±1.62% (85 runs sampled)
      cxs                    x 10,053 ops/sec ±1.32% (82 runs sampled)
      cxs-optimized          x  8,522 ops/sec ±1.53% (83 runs sampled)
      fela                   x 26,626 ops/sec ±1.51% (84 runs sampled)
      free-style             x  8,819 ops/sec ±1.60% (89 runs sampled)
      glamor                 x  4,019 ops/sec ±1.27% (88 runs sampled)
      j2c                    x 20,858 ops/sec ±2.41% (83 runs sampled)
      jss                    x  6,203 ops/sec ±1.50% (85 runs sampled)
      jss-without-preset     x  7,430 ops/sec ±1.48% (89 runs sampled)
      styletron              x 44,969 ops/sec ±1.02% (90 runs sampled)

    Fastest is: styletron


    Running style overload test.

    aphrodite length 3537
    aphrodite-no-important length 2866
    cssobj length 3207
    cxs length 2757
    cxs-optimized length 2874
    fela length 1528
    free-style length 2491
    glamor length 3034
    j2c length 4320
    jss length 3318
    jss-without-preset length 3318
    styletron length 1528

    Smallest is: fela


      aphrodite              x  1,951 ops/sec ±1.27% (88 runs sampled)
      aphrodite-no-important x  1,905 ops/sec ±1.84% (81 runs sampled)
      cssobj                 x  1,773 ops/sec ±2.59% (79 runs sampled)
      cxs                    x  3,464 ops/sec ±2.72% (78 runs sampled)
      cxs-optimized          x  2,700 ops/sec ±1.48% (84 runs sampled)
      fela                   x 18,877 ops/sec ±1.14% (83 runs sampled)
      free-style             x  3,706 ops/sec ±1.78% (87 runs sampled)
      glamor                 x  1,578 ops/sec ±1.00% (86 runs sampled)
      j2c                    x  5,825 ops/sec ±1.47% (89 runs sampled)
      jss                    x  4,717 ops/sec ±1.26% (91 runs sampled)
      jss-without-preset     x  6,186 ops/sec ±1.15% (89 runs sampled)
      styletron              x 31,217 ops/sec ±1.33% (86 runs sampled)

    Fastest is: styletron


    Running classes overload test.

    aphrodite length 2955
    aphrodite-no-important length 2504
    cssobj length 2879
    cxs length 1334
    cxs-optimized length 1713
    fela length 1078
    free-style length 1173
    glamor length 1283
    j2c length 3992
    jss length 2896
    jss-without-preset length 2896
    styletron length 1078

    Smallest is: fela


      aphrodite              x  2,227 ops/sec ±2.47% (78 runs sampled)
      aphrodite-no-important x  2,283 ops/sec ±1.58% (81 runs sampled)
      cssobj                 x  2,418 ops/sec ±1.57% (88 runs sampled)
      cxs                    x  4,694 ops/sec ±1.62% (83 runs sampled)
      cxs-optimized          x  3,413 ops/sec ±2.30% (81 runs sampled)
      fela                   x 41,599 ops/sec ±2.40% (79 runs sampled)
      free-style             x  4,491 ops/sec ±1.17% (86 runs sampled)
      glamor                 x  6,078 ops/sec ±1.19% (85 runs sampled)
      j2c                    x  7,399 ops/sec ±1.43% (88 runs sampled)
      jss                    x  5,826 ops/sec ±1.37% (89 runs sampled)
      jss-without-preset     x  7,543 ops/sec ±1.34% (88 runs sampled)
      styletron              x 65,023 ops/sec ±1.26% (91 runs sampled)

    Fastest is: styletron
</details>