### PR TITLE
Add the render target for the client-side rendering example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ const styleElements = document.getElementsByClassName('_styletron_hydrate_');
 ReactDOM.render(
   <StyletronProvider styletron={new Styletron(styleElements)}>
     <App/>
-  </StyletronProvider>
+  </StyletronProvider>,
+  document.getElementById('app')
 );
 ```
 


### PR DESCRIPTION
The client-side rendering example with React lack the render target node so it can't be copy-pasted to test it.