### PR TITLE
Pass `className` prop to components

### DIFF
--- a/packages/styletron-react/src/styled.js
+++ b/packages/styletron-react/src/styled.js
@@ -44,18 +44,18 @@ module.exports = styled;
  * <DeluxePanel>Bonjour Monde</DeluxePanel>
  */
 function styled(base, styleArg) {
-  if (typeof base === 'string') {
-    // Element
-    return createStyledElementComponent(
-      base,
-      [styleArg]
-    );
-  }
   if (typeof base === 'function' && base[TAG_KEY] && base[STYLES_KEY]) {
-    // Component
+    // Styled component
     return createStyledElementComponent(
       base[TAG_KEY],
       base[STYLES_KEY].concat(styleArg)
+    );
+  }
+  if (typeof base === 'string' || typeof base === 'function') {
+    // Tag name or non-styled component
+    return createStyledElementComponent(
+      base,
+      [styleArg]
     );
   }
   throw Error('Must pass in element or component');
@@ -76,7 +76,7 @@ function createStyledElementComponent(tagName, stylesArray) {
 
       const styletronClassName = utils.injectStylePrefixed(this.context.styletron, resolvedStyle);
 
-      const elementProps = omitInvalidProps(this.props);
+      const elementProps = typeof StyledElement[TAG_KEY] === 'string' ? omitInvalidProps(this.props) : assign({}, this.props);
       elementProps.className = this.props.className
         ? `${this.props.className} ${styletronClassName}`
         : styletronClassName;
@@ -100,6 +100,7 @@ function assign(target, source) {
   for (let key in source) {
     target[key] = source[key];
   }
+  return target;
 }
 
 function omitInvalidProps(props) {

--- a/packages/styletron-react/src/test/browser.js
+++ b/packages/styletron-react/src/test/browser.js
@@ -91,6 +91,20 @@ test('styled composition', t => {
   t.end();
 });
 
+test('styled component', t => {
+  const Widget = ({className}) => React.createElement('div', {className});
+  const SuperWidget = styled(Widget, {color: 'red'});
+  const styletron = new Styletron();
+  const output = ReactTestUtils.renderIntoDocument(
+    React.createElement(Provider, {styletron},
+      React.createElement(SuperWidget))
+  );
+  const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
+  t.equal(div.className, 'a', 'matches expected styletron classes');
+  t.equal(styletron.getCss(), '.a{color:red}');
+  t.end();
+});
+
 test('innerRef works', t => {
   t.plan(1);
 


### PR DESCRIPTION
This makes the `styled` function accept any component type. It behaves like before if you pass a tag name string or a styled component as first argument. But if you pass another component, it simply passes all props and adds the generated class names to the `className` prop and assumes that the component handles that manually.