### PR TITLE
Added bindings for Inferno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log.*
 htmldocs/
 lerna-debug.log
 lib/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ npm-debug.log.*
 htmldocs/
 lerna-debug.log
 lib/
-.DS_Store

--- a/packages/styletron-inferno/README.md
+++ b/packages/styletron-inferno/README.md
@@ -1,0 +1,127 @@
+# styletron-inferno
+
+Styletron bindings for [Inferno](https://infernojs.org/).
+
+## `Provider`
+
+`Provider` is a component that exposes a `styletron` instance to child components on their `context`.
+
+An instance of `styletron-server` or `styletron-client` must be passed to `Provider` as a `styletron` prop.
+
+**Server-side Example**
+
+```js
+import StyletronServer from 'styletron-server';
+import { Provider } from 'styletron-inferno';
+import { renderToString } from 'inferno-server';
+import express from 'express';
+import App from './path/to/app';
+
+function renderHMTL() {
+  const styletron = new StyletronServer();
+  const root = renderToString(
+    <Provider styletron={styletron}>
+      <App/>
+    </Provider>
+  );
+
+  // NOTE: getStylesheetsHtml must be called after renderToString
+  const stylesheets = styletron.getStylesheetsHtml('my-custom-class');
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        ${stylesheets}
+      </head>
+      <body>
+        <div id="root">${root}</div>
+      </body>
+    </html>
+  `;
+}
+
+const app = express();
+app.get('/', (req, res) => {
+  res.send(renderHMTL());
+});
+```
+
+**Client-side Example**
+
+```js
+import { render } from 'inferno';
+import { Provider } from 'styletron-inferno';
+import StyletronClient from 'styletron-client';
+import App from './path/to/app';
+
+const stylesheets = document.getElementsByClassName('my-custom-class');
+const styletron = new StyletronClient(stylesheets);
+
+render((
+  <Provider styletron={styletron}>
+    <App/>
+  </Provider>
+), document.getElementsById('root'));
+```
+
+## `styled(name, styles)`
+
+```
+const StyledComponent = styled(
+  name: string|function,
+  styles: object|function
+):VNode
+```
+
+`name` can be a `string` to create a styled _element_, or it can be a `class|function` _component_.
+
+`styles` can be an `object` with CSS property/value pairs, or it can be a `function` that returns an `object` with CSS property/value pairs. When a `function` is passed, it is called with `props` and `context`.
+
+```js
+import { styled } from 'styletron-inferno';
+
+const StaticStyledDiv = styled('div', {
+  backgroundColor: 'lightblue',
+  fontSize: '12px'
+});
+
+const DynamicStyledDiv = styled('div', (props) => ({
+  backgroundColor: props.alert ? 'orange' : 'lightblue',
+  fontSize: '12px'
+}));
+
+const ComposedStyledDiv = styled(StaticStyledDiv, (props) => ({
+  backgroundColor: props.alert ? 'red' : 'lime',
+  boxShadow: '0 2px 4px darkgray'
+}));
+
+Inferno.render((
+  <div>
+    <StaticStyledDiv/>
+    <DynamicStyledDiv alert={true}/>
+    <DynamicStyledDiv alert={false}/>
+    <ComposedStyledDiv alert={true}/>
+    <ComposedStyledDiv alert={false}/>
+  </div>
+), document.getElementsById('root'));
+```
+
+If you want a `ref` to the inner `DOMElement` or rendered `Component` instance, a special `innerRef` prop is provided. `innerRef` _must_ be a function—**string refs are not supported**.
+
+**NOTE:** `ref` _does not work with functional components_ since they are stateless.
+
+```js
+const StyledDiv = styled('div', {
+  backgroundColor: 'lightblue',
+  fontSize: '12px'
+});
+
+class SomeComponent extends Component {
+  componentDidMount() {
+    console.log(this.styledDiv);
+  }
+  render() {
+    return <StyledDiv innerRef={el => this.styledDiv = el}/>
+  }
+}
+```

--- a/packages/styletron-inferno/package.json
+++ b/packages/styletron-inferno/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "styletron-inferno",
+  "version": "2.5.0",
+  "description": "Inferno bindings for Styletron",
+  "author": "Matthew Wagerfield <matthew@wagerfield.com>",
+  "homepage": "https://github.com/rtsao/styletron",
+  "repository": "git@github.com:rtsao/styletron.git",
+  "bugs": "https://github.com/rtsao/styletron/issues",
+  "main": "./lib/index.js",
+  "scripts": {
+    "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "pretest": "npm run transpile",
+    "test": "../../node_modules/.bin/unitest --browser=lib/test/browser.js",
+    "prepublish": "npm run transpile"
+  },
+  "dependencies": {
+    "styletron-client": "^2.5.1",
+    "styletron-server": "^2.5.1",
+    "styletron-utils": "^2.5.1"
+  },
+  "peerDependencies": {
+    "inferno": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3"
+  },
+  "devDependencies": {
+    "inferno-test-utils": "^1.3.0-rc.3"
+  },
+  "license": "MIT"
+}

--- a/packages/styletron-inferno/src/index.js
+++ b/packages/styletron-inferno/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  Provider: require('./provider'),
+  styled: require('./styled')
+};

--- a/packages/styletron-inferno/src/provider.js
+++ b/packages/styletron-inferno/src/provider.js
@@ -1,4 +1,4 @@
-const Component = require('inferno-component');
+const InfernoComponent = require('inferno-component');
 
 /**
  * @class Provider
@@ -54,7 +54,7 @@ const Component = require('inferno-component');
  * @property {InfernoElement} children Child nodes
  * @extends InfernoComponent
  */
-class Provider extends Component {
+class StyletronProvider extends InfernoComponent {
   getChildContext() {
     return {styletron: this.styletron};
   }
@@ -67,4 +67,4 @@ class Provider extends Component {
   }
 }
 
-module.exports = Provider;
+module.exports = StyletronProvider;

--- a/packages/styletron-inferno/src/provider.js
+++ b/packages/styletron-inferno/src/provider.js
@@ -1,0 +1,70 @@
+const Component = require('inferno-component');
+
+/**
+ * @class Provider
+ * @packagename styletron-inferno
+ * @description Inferno component
+ *
+ * @example
+ * // Server
+ * import StyletronServer from 'styletron-server';
+ * import { renderToString } from 'inferno-server';
+ * import { Provider } from 'styletron-inferno';
+ * import App from '../shared/components/app';
+ *
+ * function render() {
+ *   const styletron = new StyletronServer();
+ *   const root = renderToString(
+ *     <Provider styletron={styletron}>
+ *       <App/>
+ *     </Provider>
+ *   );
+ *   const stylesheets = styletron.getStylesheetsHtml('my-custom-class');
+ *   return `
+ *     <!DOCTYPE html>
+ *     <html>
+ *       <head>
+ *         ${stylesheets}
+ *       </head>
+ *       <body>
+ *         <div id="root">${root}</div>
+ *       </body>
+ *     </html>
+ *   `;
+ * }
+ *
+ * @example
+ * // Client
+ * import Inferno from 'inferno';
+ * import StyletronClient from 'styletron-client';
+ * import { Provider } from 'styletron-inferno';
+ * import App from '../shared/components/app';
+ *
+ * function render() {
+ *   const stylesheets = document.getElementsByClassName('my-custom-class');
+ *   const styletron = new StyletronClient(stylesheets);
+ *   Inferno.render((
+ *     <Provider styletron={styletron}>
+ *       <App/>
+ *     </Provider>
+ *   ), document.getElementsById('root'));
+ * }
+ *
+ * @property {object} styletron Styletron instance
+ * @property {InfernoElement} children Child nodes
+ * @extends InfernoComponent
+ */
+class Provider extends Component {
+  getChildContext() {
+    return {styletron: this.styletron};
+  }
+  constructor(props, context) {
+    super(props, context);
+    this.styletron = props.styletron;
+  }
+  render() {
+    return this.props.children;
+  }
+}
+
+module.exports = Provider;

--- a/packages/styletron-inferno/src/styled.js
+++ b/packages/styletron-inferno/src/styled.js
@@ -3,8 +3,8 @@ const {injectStylePrefixed} = require('styletron-utils');
 const {
   assign,
   isNil,
-  isString,
   isObject,
+  isString,
   isFunction
 } = require('./utils');
 
@@ -87,7 +87,7 @@ function createStyledComponent(name, stylesArray) {
 
 function resolveStyles(stylesArray, props, context) {
   const resolvedStyles = {};
-  for (let styles, i = 0, l = stylesArray.length; i < l; i++) {
+  for (let i = 0, l = stylesArray.length, styles; i < l; i++) {
     styles = stylesArray[i];
     if (!isNil(styles)) {
       if (isFunction(styles)) {

--- a/packages/styletron-inferno/src/styled.js
+++ b/packages/styletron-inferno/src/styled.js
@@ -1,0 +1,124 @@
+const createElement = require('inferno-create-element');
+const {injectStylePrefixed} = require('styletron-utils');
+const {
+  assign,
+  isNil,
+  isString,
+  isObject,
+  isFunction
+} = require('./utils');
+
+const STYLETRON_KEY = '__STYLETRON';
+
+module.exports = styled;
+
+/**
+ * Helper function to create styled components
+ * @packagename styletron-inferno
+ * @param  {string|function} name   Tag name or component function/class
+ * @param  {function|object} styles Style object or function that returns a style object
+ * @return {function}               Styled component
+ *
+ * @example
+ * import { styled } from 'styletron-inferno';
+ *
+ * const Panel = styled('div', {
+ *   backgroundColor: 'lightblue',
+ *   fontSize: '12px'
+ * });
+ *
+ * <Panel>Hello World</Panel>
+ *
+ * @example
+ * import { styled } from 'styletron-inferno';
+ *
+ * const Panel = styled('div', (props) => ({
+ *   backgroundColor: props.alert ? 'orange' : 'lightblue',
+ *   fontSize: '12px'
+ * }));
+ *
+ * <Panel alert>Danger!</Panel>
+ *
+ * @example
+ * import { styled } from 'styletron-inferno';
+ *
+ * const DeluxePanel = styled(Panel, (props) => ({
+ *   backgroundColor: props.alert ? 'red' : 'lime',
+ *   boxShadow: '3px 3px 3px darkgray',
+ *   color: 'white'
+ * }));
+ *
+ * <DeluxePanel>Bonjour Monde</DeluxePanel>
+ */
+function styled(name, styles) {
+
+  // Styled component
+  if (name && name.hasOwnProperty(STYLETRON_KEY)) {
+    const component = name[STYLETRON_KEY];
+    const stylesArray = component.stylesArray.concat(styles);
+    return createStyledComponent(component.name, stylesArray);
+
+  // Tag name or non-styled component
+  } else if (isString(name) || isFunction(name)) {
+    return createStyledComponent(name, [styles]);
+  }
+
+  throw new Error('Must pass a tag name or component');
+}
+
+function createStyledComponent(name, stylesArray) {
+
+  function StyledComponent(props, context) {
+    const newProps = assign({}, props);
+    const styles = resolveStyles(stylesArray, props, context);
+    const className = injectStylePrefixed(context.styletron, styles);
+    newProps.className = mergeClassNames(props.className, className);
+    if (isFunction(props.innerRef)) {
+      newProps.ref = props.innerRef;
+      delete newProps.innerRef;
+    }
+    return createElement(name, newProps);
+  }
+
+  StyledComponent[STYLETRON_KEY] = {name, stylesArray};
+
+  return StyledComponent;
+}
+
+function resolveStyles(stylesArray, props, context) {
+  const resolvedStyles = {};
+  for (let styles, i = 0, l = stylesArray.length; i < l; i++) {
+    styles = stylesArray[i];
+    if (!isNil(styles)) {
+      if (isFunction(styles)) {
+        assign(resolvedStyles, styles(props, context));
+      } else if (isObject(styles)) {
+        assign(resolvedStyles, styles);
+      }
+    }
+  }
+  return resolvedStyles;
+}
+
+const SPACE_REGEX = /\s+/;
+
+function mergeClassNames(classNameA, classNameB) {
+  const a = isString(classNameA) ? classNameA : '';
+  const b = isString(classNameB) ? classNameB : '';
+
+  // Join class name strings then split on whitespace
+  const classNames = (`${a} ${b}`).trim().split(SPACE_REGEX);
+  const classNameCache = {};
+  const uniqueClasses = [];
+
+  // Deduplicate and remove empty class names
+  for (let className, i = 0, l = classNames.length; i < l; i++) {
+    className = classNames[i];
+    if (!classNameCache[className]) {
+      classNameCache[className] = true;
+      uniqueClasses.push(className);
+    }
+  }
+
+  return uniqueClasses.join(' ');
+}

--- a/packages/styletron-inferno/src/test/browser.js
+++ b/packages/styletron-inferno/src/test/browser.js
@@ -161,7 +161,7 @@ test('innerRef works', (t) => {
         innerRef: styledDiv => {
           t.ok(styledDiv instanceof HTMLDivElement, 'element ref passed');
           t.equal(styledDiv.className, 'a', 'matches expected className');
-          this.styledDiv = styledDiv
+          this.styledDiv = styledDiv;
         }
       });
     }
@@ -196,7 +196,7 @@ test('innerRef not passed', (t) => {
         foo: 'bar',
         innerRef: innerComponent => {
           t.ok(InfernoTestUtils.isRenderedClassComponentOfType(innerComponent, InnerComponent), 'is InnerComponent');
-          this.innerComponent = innerComponent
+          this.innerComponent = innerComponent;
         }
       });
     }

--- a/packages/styletron-inferno/src/test/browser.js
+++ b/packages/styletron-inferno/src/test/browser.js
@@ -1,0 +1,210 @@
+const test = require('tape');
+const createElement = require('inferno-create-element');
+const InfernoComponent = require('inferno-component');
+const InfernoTestUtils = require('inferno-test-utils');
+const StyletronServer = require('styletron-server');
+const Provider = require('../provider');
+const styled = require('../styled');
+
+test('Provider provides Styletron instance on component context', (t) => {
+  t.plan(1);
+  const mockStyletronInstance = {};
+
+  const MockComponent = (props, context) => {
+    t.equal(context.styletron, mockStyletronInstance,
+      'Styletron instance on component context');
+    return createElement('div');
+  };
+
+  InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {
+      styletron: mockStyletronInstance
+    }, createElement(MockComponent))
+  );
+});
+
+test('props passed to styled function', (t) => {
+  t.plan(1);
+  const mockProps = {foo: 'bar'};
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', (props) => {
+    t.deepEqual(props, mockProps, 'props accessible in styled function');
+    return {};
+  });
+
+  InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(StyledComponent, mockProps)
+    )
+  );
+});
+
+test('styled applies styles object', (t) => {
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', {color: 'red'});
+
+  const result = InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(StyledComponent)
+    )
+  );
+
+  const element = InfernoTestUtils.findRenderedDOMElementWithTag(result, 'div');
+
+  t.equal(element.className, 'a', 'matches expected className');
+  t.equal(styletron.getCss(), '.a{color:red}', 'matches expected CSS');
+  t.end();
+});
+
+test('styled applies styles function', (t) => {
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', (props) => ({
+    [props.property]: props.value
+  }));
+
+  const result = InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(StyledComponent, {
+        property: 'color',
+        value: 'red'
+      })
+    )
+  );
+
+  const element = InfernoTestUtils.findRenderedDOMElementWithTag(result, 'div');
+
+  t.equal(element.className, 'a', 'matches expected className');
+  t.equal(styletron.getCss(), '.a{color:red}', 'matches expected CSS');
+  t.end();
+});
+
+test('styled passes through valid props', (t) => {
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', {color: 'red'});
+
+  const result = InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(StyledComponent, {
+        'data-bar': 'bar'
+      })
+    )
+  );
+
+  const element = InfernoTestUtils.findRenderedDOMElementWithTag(result, 'div');
+
+  t.equal(element.getAttribute('data-bar'), 'bar', 'valid attribute prop passed through');
+  t.end();
+});
+
+test('styled composition', (t) => {
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', {
+    display: 'inline',   // .a
+    color: 'red'         // .b
+  });
+
+  const SuperStyledComponent = styled(StyledComponent, {
+    background: 'black', // .c
+    display: 'block'     // .a (replaced)
+  });
+
+  const result = InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(SuperStyledComponent)
+    )
+  );
+
+  const element = InfernoTestUtils.findRenderedDOMElementWithTag(result, 'div');
+
+  t.equal(element.className, 'a b c', 'matches expected className');
+  t.equal(styletron.getCss(), '.a{display:block}.b{color:red}.c{background:black}', 'matches expected CSS');
+  t.end();
+});
+
+test('styled component', (t) => {
+  const styletron = new StyletronServer();
+
+  const BaseComponent = (props) => createElement('div', props);
+  const StyledComponent = styled(BaseComponent, {color: 'red'});
+
+  const result = InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(StyledComponent)
+    )
+  );
+
+  const element = InfernoTestUtils.findRenderedDOMElementWithTag(result, 'div');
+
+  t.equal(element.className, 'a', 'matches expected className');
+  t.equal(styletron.getCss(), '.a{color:red}', 'matches expected CSS');
+  t.end();
+});
+
+test('innerRef works', (t) => {
+  t.plan(3);
+
+  const styletron = new StyletronServer();
+
+  const StyledComponent = styled('div', {color: 'red'});
+
+  class ClassComponent extends InfernoComponent {
+    componentDidMount() {
+      t.ok(this.styledDiv instanceof HTMLDivElement, 'element ref passed');
+    }
+    render() {
+      return createElement(StyledComponent, {
+        innerRef: styledDiv => {
+          t.ok(styledDiv instanceof HTMLDivElement, 'element ref passed');
+          t.equal(styledDiv.className, 'a', 'matches expected className');
+          this.styledDiv = styledDiv
+        }
+      });
+    }
+  }
+
+  InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(ClassComponent)
+    )
+  );
+});
+
+test('innerRef not passed', (t) => {
+  t.plan(3);
+  const styletron = new StyletronServer();
+
+  class InnerComponent extends InfernoComponent {
+    render() {
+      t.deepEqual(this.props, {className: 'a', foo: 'bar'}, 'matches expected props');
+      return createElement('div');
+    }
+  }
+
+  const StyledInnerComponent = styled(InnerComponent, {color: 'red'});
+
+  class ClassComponent extends InfernoComponent {
+    componentDidMount() {
+      t.ok(InfernoTestUtils.isRenderedClassComponentOfType(this.innerComponent, InnerComponent), 'is InnerComponent');
+    }
+    render() {
+      return createElement(StyledInnerComponent, {
+        foo: 'bar',
+        innerRef: innerComponent => {
+          t.ok(InfernoTestUtils.isRenderedClassComponentOfType(innerComponent, InnerComponent), 'is InnerComponent');
+          this.innerComponent = innerComponent
+        }
+      });
+    }
+  }
+
+  InfernoTestUtils.renderIntoDocument(
+    createElement(Provider, {styletron},
+      createElement(ClassComponent)
+    )
+  );
+});

--- a/packages/styletron-inferno/src/utils.js
+++ b/packages/styletron-inferno/src/utils.js
@@ -1,0 +1,34 @@
+function isType(value, type) {
+  return typeof value === type;
+}
+
+function isFunction(value) {
+  return isType(value, 'function');
+}
+
+function isObject(value) {
+  return isType(value, 'object');
+}
+
+function isString(value) {
+  return isType(value, 'string');
+}
+
+function isNil(value) {
+  return value === null || value === undefined;
+}
+
+function assign(target, source) {
+  for (let key in source) {
+    target[key] = source[key];
+  }
+  return target;
+}
+
+module.exports = {
+  isFunction,
+  isObject,
+  isString,
+  isNil,
+  assign
+};


### PR DESCRIPTION
It's finally here...Styletron bindings for [Inferno](https://infernojs.org/) 🎉 

Par a few minor differences, this package behaves in exactly the same way as `styletron-react`. 

The notable differences are as follows:

1. `StyletronProvider` is just called `Provider`—the majority of other bindings out there for Redux, MobX etc. all use the non-prefixed `Provider` name, so I thought we should follow convention. If the user is using a number of providers, they can simply name them accordingly when they `import/require` them.
2. The `styled` function params are called `name` and `styles` as opposed to `base` and `styleArg`. `name` is the param name used in Inferno's `createElement` function and `styles`...well just because I don't think `Arg` is needed :)
3. I omitted the `isValidAttr` parser because Inferno handles this internally. Unless I'm missing something, I don't think it's necessary.
4. I made a few optimisations to the `styled` implementation (such as using for loops over lambdas and using a functional component rather than a class component to return the styled component).
5. I also stored the `name` and `stylesArray` on a single `__STYLETRON` object instead of 2 separate keys (`__STYLETRON_STYLES` and `__STYLETRON_TAG`) because I thought it was a little neater.
6. I created some generic `utils` like `assign` and a few type checkers like `isString`, `isObject` etc. These are obviously very generic, so if you're doing these checks anywhere else, perhaps we could hoist them into `styletron-utils` for other `styletron` packages to use and reduce the footprint?

In addition to the above, I have also written a pretty comprehensive `README` to compliment the JavaDocs that I have added in `provider.js` and `styled.js`.

Perhaps the changes above could be rolled into the React version? Happy to do that if you're in agreement.

This PR resolves https://github.com/rtsao/styletron/issues/50