### PR TITLE
Create `injectStyle` function with plugins and middlewares

### DIFF
--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -1,9 +1,14 @@
 import * as React from "react";
 import StyletronServer from "styletron-server";
 import StyletronClient from "styletron-client";
+import {InjectStyle} from 'styletron-utils';
 
 declare namespace StyletronReact {
-  export class StyletronProvider extends React.Component<{styletron: StyletronServer | StyletronClient}, void> {}
+  type ProviderPropType = {
+    styletron?: StyletronServer | StyletronClient;
+    injectStyle?: InjectStyle;
+  };
+  export class StyletronProvider extends React.Component<ProviderPropType, void> {}
 
   type InnerRef<TInstance> = {
     innerRef?: (instance: TInstance) => any;

--- a/packages/styletron-react/src/provider.js
+++ b/packages/styletron-react/src/provider.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
+const {injectStylePrefixed} = require('styletron-utils');
 
 /**
  * @class StyletronProvider
@@ -15,18 +16,21 @@ const PropTypes = require('prop-types');
  *     </StyletronProvider>
  *   );
  * }
- * 
+ *
  * @property {object} styletron - Styletron instance
  * @property {ReactElement} children - children
  * @extends ReactClass
  */
 class StyletronProvider extends React.Component {
   getChildContext() {
-    return {styletron: this.styletron};
+    return this.childContext;
   }
   constructor(props, context) {
     super(props, context);
-    this.styletron = props.styletron;
+    this.childContext = {
+      styletron: props.styletron || context.styletron,
+      injectStyle: props.injectStyle || context.injectStyle || injectStylePrefixed
+    };
   }
   render() {
     return React.Children.only(this.props.children);
@@ -34,12 +38,13 @@ class StyletronProvider extends React.Component {
 }
 
 StyletronProvider.PropTypes = {
-  styletron: PropTypes.object.isRequired,
-  children: PropTypes.element.isRequired
+  styletron: PropTypes.object,
+  children: PropTypes.element
 };
 
-StyletronProvider.childContextTypes = {
-  styletron: PropTypes.object.isRequired
+StyletronProvider.contextTypes = StyletronProvider.childContextTypes = {
+  styletron: PropTypes.object,
+  injectStyle: PropTypes.func
 };
 
 module.exports = StyletronProvider;

--- a/packages/styletron-react/src/styled.js
+++ b/packages/styletron-react/src/styled.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const utils = require('styletron-utils');
 
 const isValidAttr = require('./is-valid-attr');
 
@@ -70,10 +69,7 @@ function createStyledElementComponent(tagName, stylesArray) {
       }
     });
 
-    const styletronClassName = utils.injectStylePrefixed(
-      context.styletron,
-      resolvedStyle
-    );
+    const styletronClassName = context.injectStyle(context.styletron, resolvedStyle);
 
     const elementProps = typeof StyledElement[STYLETRON_KEY].tag === 'string'
       ? omitInvalidProps(restProps)
@@ -95,7 +91,10 @@ function createStyledElementComponent(tagName, stylesArray) {
     tag: tagName,
     styles: stylesArray
   };
-  StyledElement.contextTypes = {styletron: PropTypes.object};
+  StyledElement.contextTypes = {
+    styletron: PropTypes.object.isRequired,
+    injectStyle: PropTypes.func.isRequired
+  };
 
   return StyledElement;
 }

--- a/packages/styletron-react/yarn.lock
+++ b/packages/styletron-react/yarn.lock
@@ -5,3 +5,126 @@
 "@types/react@*":
   version "15.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.21.tgz#29d849427237c1463abfb7b370755ee3e5b5b375"
+
+asap@~2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
+bowser@^1.0.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.1.tgz#9157e9498f456e937173a2918f3b2161e5353eb3"
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+hyphenate-style-name@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
+iconv-lite@~0.4.13:
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.16.tgz#65de3beeb39e2960d67f049f1634ffcbcde9014b"
+
+inline-style-prefixer@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
+  dependencies:
+    bowser "^1.0.0"
+    hyphenate-style-name "^1.0.1"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
+js-tokens@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
+node-fetch@^1.0.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+promise@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+styletron-client@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-client/-/styletron-client-2.5.7.tgz#104fa4dc564cd3fe78eb92488e5ef9039c9e242f"
+  dependencies:
+    styletron-core "^2.5.7"
+
+styletron-core@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-core/-/styletron-core-2.5.7.tgz#2c4a1fae537b42235462e438c24ab619bbf8993e"
+
+styletron-server@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-server/-/styletron-server-2.5.7.tgz#f3d0e86e1b8540cde10f25bfa08c40dc0df3851f"
+  dependencies:
+    styletron-core "^2.5.7"
+
+styletron-utils@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/styletron-utils/-/styletron-utils-2.5.4.tgz#f08cca7d58ee0338ce85e408cb32900e65620240"
+  dependencies:
+    inline-style-prefixer "^2.0.1"
+
+ua-parser-js@^0.7.9:
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"

--- a/packages/styletron-utils/index.d.ts
+++ b/packages/styletron-utils/index.d.ts
@@ -1,0 +1,13 @@
+import StyletronServer from "styletron-server";
+import StyletronClient from "styletron-client";
+
+declare namespace StyletronUtils {
+  type InjectStyle = (styletron: StyletronServer | StyletronClient, styles: Object, media?: string, pseudo?: string) => string;
+  type CreateInjectStyle = (plugins?: (styles: Object) => Object, ...middlewares: Function[]) => InjectStyle;
+
+  export var createInjectStyle: CreateInjectStyle;
+  export var injectStyle: InjectStyle;
+  export var injectStylePrefixed: InjectStyle;
+}
+
+export = StyletronUtils;

--- a/packages/styletron-utils/package.json
+++ b/packages/styletron-utils/package.json
@@ -7,6 +7,7 @@
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
   "main": "./lib/index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
     "pretest": "npm run transpile",
@@ -14,7 +15,9 @@
     "prepublish": "npm run transpile"
   },
   "dependencies": {
-    "inline-style-prefixer": "^2.0.1"
+    "inline-style-prefixer": "^3.0.0",
+    "styletron-client": "^2.5.7",
+    "styletron-server": "^2.5.7"
   },
   "devDependencies": {},
   "license": "MIT"

--- a/packages/styletron-utils/src/compose.js
+++ b/packages/styletron-utils/src/compose.js
@@ -1,0 +1,5 @@
+module.exports = compose;
+
+function compose(...fns) {
+  return arg => fns.reduceRight((result, fn) => fn(result), arg);
+}

--- a/packages/styletron-utils/src/create-inject-style.js
+++ b/packages/styletron-utils/src/create-inject-style.js
@@ -1,0 +1,41 @@
+const hyphenate = require('./hyphenate-style-name');
+const fallbackValueMiddleware = require('./fallback-value-middleware');
+const mediaMiddleware = require('./media-middleware');
+const pseudoMiddleware = require('./psuedo-middleware');
+
+module.exports = createInjectStyle;
+
+function createInjectStyle(plugins, ...customMiddlewares) {
+  const middlewares = customMiddlewares.length > 0 ? customMiddlewares : [
+    fallbackValueMiddleware,
+    mediaMiddleware,
+    pseudoMiddleware
+  ];
+
+  return (styletron, styles, media, pseudo) => {
+    const resolve = (prop, val, media, pseudo) => {
+      if (typeof val === 'string' || typeof val === 'number') {
+        return ' ' + styletron.injectDeclaration({prop: hyphenate(prop), val, media, pseudo});
+      }
+
+      for (let i = 0; i < middlewares.length; i++) {
+        const classNames = middlewares[i](prop, val, media, pseudo, resolve);
+        if (classNames) {
+          return classNames;
+        }
+      }
+
+      return '';
+    };
+
+    const result = typeof plugins === 'function' ? plugins(styles) : styles;
+
+    let classNames = '';
+    for (let prop in result) {
+      classNames += resolve(prop, result[prop], media, pseudo);
+    }
+
+    // Remove leading space on way out
+    return classNames.slice(1);
+  };
+}

--- a/packages/styletron-utils/src/fallback-value-middleware.js
+++ b/packages/styletron-utils/src/fallback-value-middleware.js
@@ -1,0 +1,11 @@
+module.exports = fallbackValueMiddleware;
+
+function fallbackValueMiddleware(prop, val, media, pseudo, resolve) {
+  let classNames = '';
+  if (Array.isArray(val)) {
+    for (let i = 0; i < val.length; i++) {
+      classNames += resolve(prop, val[i], media, pseudo);
+    }
+  }
+  return classNames;
+}

--- a/packages/styletron-utils/src/index.js
+++ b/packages/styletron-utils/src/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  createInjectStyle: require('./create-inject-style'),
   injectStyle: require('./inject-style'),
   injectStylePrefixed: require('./inject-style-prefixed')
 };

--- a/packages/styletron-utils/src/inject-style-prefixed.js
+++ b/packages/styletron-utils/src/inject-style-prefixed.js
@@ -1,97 +1,23 @@
-const prefixProperties = require('inline-style-prefixer/lib/static/prefixProps');
-const capitalizeString = require('inline-style-prefixer/lib/utils/capitalizeString');
-const prefixPropertiesArray = Object.keys(prefixProperties);
-
-const calc = require('inline-style-prefixer/lib/static/plugins/calc');
-const cursor = require('inline-style-prefixer/lib/static/plugins/cursor');
-const flex = require('inline-style-prefixer/lib/static/plugins/flex');
-const sizing = require('inline-style-prefixer/lib/static/plugins/sizing');
-const gradient = require('inline-style-prefixer/lib/static/plugins/gradient');
-const transition = require('inline-style-prefixer/lib/static/plugins/transition');
-// special flexbox specifications
-const flexboxIE = require('inline-style-prefixer/lib/static/plugins/flexboxIE');
-const flexboxOld = require('inline-style-prefixer/lib/static/plugins/flexboxOld');
+const createPrefixer = require('inline-style-prefixer/static/createPrefixer');
+const staticData = require('inline-style-prefixer/static/staticData');
 
 const plugins = [
-  calc,
-  cursor,
-  sizing,
-  gradient,
-  transition,
-  flexboxIE,
-  flexboxOld,
-  flex
+  require('inline-style-prefixer/static/plugins/calc'),
+  require('inline-style-prefixer/static/plugins/cursor'),
+  require('inline-style-prefixer/static/plugins/flex'),
+  require('inline-style-prefixer/static/plugins/sizing'),
+  require('inline-style-prefixer/static/plugins/gradient'),
+  require('inline-style-prefixer/static/plugins/transition'),
+  // special flexbox specifications
+  require('inline-style-prefixer/static/plugins/flexboxIE'),
+  require('inline-style-prefixer/static/plugins/flexboxOld'),
 ];
 
-const hyphenate = require('./hyphenate-style-name');
+const prefixAll = createPrefixer({
+  prefixMap: staticData.prefixMap,
+  plugins,
+});
 
-module.exports = injectStyle;
+const createInjectStyle = require('./create-inject-style');
 
-function injectStyle(styletron, styles, media, pseudo) {
-  let classString = '';
-  for (let key in styles) {
-    const val = styles[key];
-    const valType = typeof val;
-    if (valType === 'string' || valType === 'number') {
-      // handle vendor prefixed properties
-      for (let i = 0; i < prefixPropertiesArray.length; i++) {
-        const prefix = prefixPropertiesArray[i];
-        const properties = prefixProperties[prefix];
-        if (properties[key]) {
-          const prefixedPropName = prefix + capitalizeString(key);
-          classString += ' ' + injectWithPlugins(styletron, prefixedPropName, val, media, pseudo);
-        }
-      }
-      // handle un-prefixed
-      classString += ' ' + injectWithPlugins(styletron, key, val, media, pseudo);
-      continue;
-    }
-    if (Array.isArray(val)) {
-      for (let i = 0; i < val.length; i++) {
-        classString += ' ' + injectWithPlugins(styletron, key, val[i], media, pseudo);
-      }
-      continue;
-    }
-    if (valType === 'object') {
-      if (key[0] === ':') {
-        classString += ' ' + injectStyle(styletron, val, media, key);
-        continue;
-      }
-      if (key.substring(0, 6) === '@media') {
-        classString += ' ' + injectStyle(styletron, val, key.substr(7), pseudo);
-        continue;
-      }
-    }
-  }
-  // remove leading space on way out
-  return classString.slice(1);
-}
-
-function injectWithPlugins(styletron, prop, val, media, pseudo) {
-  let classString = '';
-  const baseHyphenated = hyphenate(prop);
-  for (let i = 0; i < plugins.length; i++) {
-    const plugin = plugins[i];
-    const res = plugin(prop, val);
-    if (res) {
-      for (let key in res) {
-        const resVal = res[key];
-        const hyphenated = hyphenate(key);
-        const propIsDifferent = hyphenated !== baseHyphenated;
-        if (Array.isArray(resVal)) {
-          for (let j = 0; j < resVal.length; j++) {
-            if (propIsDifferent || resVal[j] !== val) {
-              classString += ' ' + styletron.injectDeclaration({prop: hyphenated, val: resVal[j], media, pseudo});
-            }
-          }
-        } else if (propIsDifferent || resVal !== val) {
-          classString += ' ' + styletron.injectDeclaration({prop: hyphenated, val: resVal, media, pseudo});
-        }
-      }
-    }
-  }
-  // inject original last
-  classString += ' ' + styletron.injectDeclaration({prop: baseHyphenated, val, media, pseudo});
-  // remove leading space on way out
-  return classString.slice(1);
-}
+module.exports = createInjectStyle(prefixAll);

--- a/packages/styletron-utils/src/inject-style.js
+++ b/packages/styletron-utils/src/inject-style.js
@@ -1,34 +1,3 @@
-const hyphenate = require('./hyphenate-style-name');
+const createInjectStyle = require('./create-inject-style');
 
-module.exports = injectStyle;
-
-function injectStyle(styletron, styles, media, pseudo) {
-  let classString = '';
-  for (let key in styles) {
-    const val = styles[key];
-    const valType = typeof val;
-    if (valType === 'string' || valType === 'number') {
-      classString += ' ' + styletron.injectDeclaration({prop: hyphenate(key), val, media, pseudo});
-      continue;
-    }
-    if (Array.isArray(val)) {
-      for (let i = 0; i < val.length; i++) {
-        const hyphenated = hyphenate(key);
-        classString += ' ' + styletron.injectDeclaration({prop: hyphenated, val: val[i], media, pseudo});
-      }
-      continue;
-    }
-    if (valType === 'object') {
-      if (key[0] === ':') {
-        classString += ' ' + injectStyle(styletron, val, media, key);
-        continue;
-      }
-      if (key.substring(0, 6) === '@media') {
-        classString += ' ' + injectStyle(styletron, val, key.substr(7), pseudo);
-        continue;
-      }
-    }
-  }
-  // remove leading space on way out
-  return classString.slice(1);
-}
+module.exports = createInjectStyle();

--- a/packages/styletron-utils/src/media-middleware.js
+++ b/packages/styletron-utils/src/media-middleware.js
@@ -1,0 +1,12 @@
+module.exports = mediaMiddleware;
+
+function mediaMiddleware(prop, val, x, psuedo, resolve) {
+  let classNames = '';
+  if (typeof val === 'object' && prop.substring(0, 6) === '@media') {
+    const media = prop.substr(7);
+    for (let key in val) {
+      classNames += resolve(key, val[key], media, psuedo);
+    }
+  }
+  return classNames;
+}

--- a/packages/styletron-utils/src/psuedo-middleware.js
+++ b/packages/styletron-utils/src/psuedo-middleware.js
@@ -1,0 +1,11 @@
+module.exports = psuedoMiddleware;
+
+function psuedoMiddleware(prop, val, media, x, resolve) {
+  let classNames = '';
+  if (typeof val === 'object' && prop[0] === ':') {
+    for (let key in val) {
+      classNames += resolve(key, val[key], media, prop);
+    }
+  }
+  return classNames;
+}

--- a/packages/styletron-utils/src/test/index.js
+++ b/packages/styletron-utils/src/test/index.js
@@ -68,23 +68,34 @@ test('test injection prefixed', function (t) {
     }
   };
   const classString = injectStylePrefixed(spy, {
-    width: 'calc(100%)',
     height: ['min-content', 'calc(50%)'],
-    boxSizing: 'border-box'
+    transition: 'background 1s',
+    ':hover': {
+      background: 'linear-gradient(to bottom, white, black)',
+    },
+    '@media (min-width: 768px)': {
+      display: 'flex',
+    }
   });
-  t.equal(classString, '1 2 3 4 5 6 7 8 9 10 11');
+  t.equal(classString, '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17');
   t.deepEqual(decls, [
-    {prop: 'width', val: '-webkit-calc(100%)', media: undefined, pseudo: undefined},
-    {prop: 'width', val: '-moz-calc(100%)', media: undefined, pseudo: undefined},
-    {prop: 'width', val: 'calc(100%)', media: undefined, pseudo: undefined},
     {prop: 'height', val: '-webkit-min-content', media: undefined, pseudo: undefined},
     {prop: 'height', val: '-moz-min-content', media: undefined, pseudo: undefined},
     {prop: 'height', val: 'min-content', media: undefined, pseudo: undefined},
     {prop: 'height', val: '-webkit-calc(50%)', media: undefined, pseudo: undefined},
     {prop: 'height', val: '-moz-calc(50%)', media: undefined, pseudo: undefined},
     {prop: 'height', val: 'calc(50%)', media: undefined, pseudo: undefined},
-    {prop: '-moz-box-sizing', val: 'border-box', media: undefined, pseudo: undefined},
-    {prop: 'box-sizing', val: 'border-box', media: undefined, pseudo: undefined}
+    {prop: 'transition', val: 'background 1s', media: undefined, pseudo: undefined},
+    {prop: 'background', val: '-webkit-linear-gradient(to bottom, white, black)', media: undefined, pseudo: ':hover'},
+    {prop: 'background', val: '-moz-linear-gradient(to bottom, white, black)', media: undefined, pseudo: ':hover'},
+    {prop: 'background', val: 'linear-gradient(to bottom, white, black)', media: undefined, pseudo: ':hover'},
+    {prop: 'display', val: '-webkit-box', media: '(min-width: 768px)', pseudo: undefined},
+    {prop: 'display', val: '-moz-box', media: '(min-width: 768px)', pseudo: undefined},
+    {prop: 'display', val: '-ms-flexbox', media: '(min-width: 768px)', pseudo: undefined},
+    {prop: 'display', val: '-webkit-flex', media: '(min-width: 768px)', pseudo: undefined},
+    {prop: 'display', val: 'flex', media: '(min-width: 768px)', pseudo: undefined},
+    {prop: '-webkit-transition', val: 'background 1s', media: undefined, pseudo: undefined},
+    {prop: '-moz-transition', val: 'background 1s', media: undefined, pseudo: undefined}
   ]);
   t.end();
 });

--- a/packages/styletron-utils/yarn.lock
+++ b/packages/styletron-utils/yarn.lock
@@ -2,17 +2,39 @@
 # yarn lockfile v1
 
 
-bowser@^1.0.0:
+bowser@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.1.tgz#9157e9498f456e937173a2918f3b2161e5353eb3"
 
-hyphenate-style-name@^1.0.1:
+css-in-js-utils@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz#9ac7e02f763cf85d94017666565ed68a5b5f3215"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
+hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-inline-style-prefixer@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
+inline-style-prefixer@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.2.tgz#989865e0c5de7a946acbea71e16e02741efe0dd7"
   dependencies:
-    bowser "^1.0.0"
-    hyphenate-style-name "^1.0.1"
+    bowser "^1.6.0"
+    css-in-js-utils "^1.0.3"
+
+styletron-client@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-client/-/styletron-client-2.5.7.tgz#104fa4dc564cd3fe78eb92488e5ef9039c9e242f"
+  dependencies:
+    styletron-core "^2.5.7"
+
+styletron-core@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-core/-/styletron-core-2.5.7.tgz#2c4a1fae537b42235462e438c24ab619bbf8993e"
+
+styletron-server@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/styletron-server/-/styletron-server-2.5.7.tgz#f3d0e86e1b8540cde10f25bfa08c40dc0df3851f"
+  dependencies:
+    styletron-core "^2.5.7"


### PR DESCRIPTION
Basically replaces the whole `styletron-utils` package with the ability to provide plugins to manipulate styles before the declarations injects through middlewares.

~~Note that I took a little bit of a chance and did a change that might cause a major release. The major change is that you pass the `styletron` instance as only argument to `injectStyle` which returns a new function that accepts the other three (`style`, `media` and `pseudo`). The reason I made that choice:~~
- ~~`injectStyle` is now a required prop for `<StyletronProvider />` otherwise we force it to bundle even when it's not used~~
- ~~It felt unnecessary to pass both `styletron` and `injectStyle` as prop to `<StyletronProvider />` when the instance provides `injectStyle` with a single method and nothing else.~~ 
- ~~I believe it also feels more natural to reuse the function for other use cases: `module export injectStyle(styletron)`~~

~~I understand that there may be other than React users to take in consideration but if this may cause any trouble or you don't agree, just let me know.~~

Here's an example of a basic implementation:

```jsx
import StyletronClient from 'styletron-client';
import {StyletronProvider} from 'styletron-react';
import {injectStyle} from 'styletron-utils';

const styletron = new StyletronClient();
<StyletronProvider styletron={styletron} injectStyle={injectStyle}>{...}</StyletronProvider>
```

To make a custom `injectStyle` you simply pass a plugin or multiple composed plugins as first argument to `createInjectStyle`:

```jsx
import StyletronClient from 'styletron-client';
import {StyletronProvider} from 'styletron-react';
import {createInjectStyle} from 'styletron-utils';
import prefixAll from 'inline-style-prefixer';
import otherStylePlugin from 'third-party-style-plugin';

const compose = (...fns) => initial => fns.reduceRight((result, fn) => fn(result), initial);

const styletron = new StyletronClient();
const injectStyle = createInjectStyle(compose(prefixAll, otherStylePlugin));
<StyletronProvider styletron={styletron} injectStyle={injectStyle}>{...}</StyletronProvider>
```

This term middleware in this case are functions that handles array values and media- and psuedo properties. These are also overridable for customization. But if you define a middleware, the default ones won't be included and you will have to add those you want manually:

```js
const injectStyle = createInjectStyle(
  compose(prefixAll, otherStylePlugin),
  customMiddleware,
  fallbackValueMiddleware,
  mediaMiddleware,
  pseudoMiddleware
);
```

Fixes #39

~~EDIT~~

~~A featured "old" `<StyletronProvider />` with `injectStylePrefixed` as default is now accessible by importing `styletron-react/featured`. So that will be the tiniest effort `styletron-react` users will have to change after an upgrade. If someone doesn't change the import path or provide an `injetStyle` prop, it will throw.~~

~~The reason I choose this solution and not the contrary (a `injectStyle` provider from `styletron-react/custom`) is because you would in that case have to import `styletron-react/custom` everywhere if your bundler doesn't provide tree-shaking.~~
