### PR TITLE
Added basic support for keyframe animations

### DIFF
--- a/packages/styletron-client-ie9/src/__tests__/browser.js
+++ b/packages/styletron-client-ie9/src/__tests__/browser.js
@@ -24,7 +24,7 @@ class StyletronTest extends Styletron {
 test('hydration basic', t => {
   const elements = createFixtures([
     {
-      css: '.e:hover{display:none}.a{color:red}.b{color:green}',
+      css: '@keyframes f{0%{border-bottom:1px;margin-left:0}100%{border-bottom:10px;margin-left:10px}}.e:hover{display:none}.a{color:red}.b{color:green}.f{animation-name:f}',
     },
     {
       media: '(max-width: 800px)',
@@ -33,13 +33,13 @@ test('hydration basic', t => {
   ]);
   const instance = new StyletronTest(elements);
   t.deepEqual(instance.getCache(), fixtures.basic.cache, 'cache hydrated');
-  t.equal(instance.getUniqueDeclarationCount(), 5, 'count correctly hyrdated');
+  t.equal(instance.getUniqueDeclarationCount(), 6, 'count correctly hyrdated');
   const newClass = instance.injectDeclaration({
     prop: 'color',
     val: 'purple',
     media: '(max-width: 800px)',
   });
-  t.equal(newClass, 'f', 'new class with correct count');
+  t.equal(newClass, 'g', 'new class with correct count');
   t.end();
 });
 

--- a/packages/styletron-client/src/__tests__/browser.js
+++ b/packages/styletron-client/src/__tests__/browser.js
@@ -24,7 +24,7 @@ class StyletronTest extends Styletron {
 test('hydration basic', t => {
   const elements = createFixtures([
     {
-      css: '.e:hover{display:none}.a{color:red}.b{color:green}',
+      css: '@keyframes f{0%{border-bottom:1px;margin-left:0}100%{border-bottom:10px;margin-left:10px}}.f{animation-name:f}.e:hover{display:none}.a{color:red}.b{color:green}',
     },
     {
       media: '(max-width: 800px)',
@@ -33,13 +33,13 @@ test('hydration basic', t => {
   ]);
   const instance = new StyletronTest(elements);
   t.deepEqual(instance.getCache(), fixtures.basic.cache, 'cache hydrated');
-  t.equal(instance.getUniqueDeclarationCount(), 5, 'count correctly hyrdated');
+  t.equal(instance.getUniqueDeclarationCount(), 6, 'count correctly hyrdated');
   const newClass = instance.injectDeclaration({
     prop: 'color',
     val: 'purple',
     media: '(max-width: 800px)',
   });
-  t.equal(newClass, 'f', 'new class with correct count');
+  t.equal(newClass, 'g', 'new class with correct count');
   t.end();
 });
 

--- a/packages/styletron-client/src/index.js
+++ b/packages/styletron-client/src/index.js
@@ -131,6 +131,10 @@ function declarationToRule(className, {prop, val, pseudo}) {
         }
         keyframes.push(`${kf}{${properties.join(';')}}`);
       }
+<<<<<<< HEAD:packages/styletron-client/src/index.js
+=======
+      keyframes.push(`${kf}{${properties.join(';')}}`);
+>>>>>>> brushed the code to silence the linter:packages/styletron-client/src/styletron-client.js
     }
     return `@keyframes ${className}{${keyframes.join('')}}.${className}{animation-name:${className}}`;
   }
@@ -157,6 +161,7 @@ function keyframeStringToJSObject(keyframeString) {
       .map(keyframe => {
         const key = keyframe.split('{'); // separate keyframe value from rules
 
+<<<<<<< HEAD:packages/styletron-client/src/index.js
         // handle multiple rules
         const rules = key[1]
           .split(';')
@@ -173,4 +178,19 @@ function keyframeStringToJSObject(keyframeString) {
       // combine array of keyframes into a single object
       .reduce((keySet, keyframe) => Object.assign(keySet, keyframe), {})
   );
+=======
+      // handle multiple rules
+      const rules = key[1].split(';').map(rule => {
+        // return {prop: value} object
+        const prop = rule.split(':');
+        return {[prop[0]]: prop[1]};
+      })
+      .reduce((ruleSet, rule) => Object.assign(ruleSet, rule), {}); // combine array of rules into a single object
+
+      // return rules for current keyframe
+      return {[key[0]]: rules};
+    })
+    // combine array of keyframes into a single object
+    .reduce((keySet, keyframe) => Object.assign(keySet, keyframe), {});
+>>>>>>> brushed the code to silence the linter:packages/styletron-client/src/styletron-client.js
 }

--- a/packages/styletron-client/src/index.js
+++ b/packages/styletron-client/src/index.js
@@ -131,10 +131,6 @@ function declarationToRule(className, {prop, val, pseudo}) {
         }
         keyframes.push(`${kf}{${properties.join(';')}}`);
       }
-<<<<<<< HEAD:packages/styletron-client/src/index.js
-=======
-      keyframes.push(`${kf}{${properties.join(';')}}`);
->>>>>>> brushed the code to silence the linter:packages/styletron-client/src/styletron-client.js
     }
     return `@keyframes ${className}{${keyframes.join('')}}.${className}{animation-name:${className}}`;
   }
@@ -161,7 +157,6 @@ function keyframeStringToJSObject(keyframeString) {
       .map(keyframe => {
         const key = keyframe.split('{'); // separate keyframe value from rules
 
-<<<<<<< HEAD:packages/styletron-client/src/index.js
         // handle multiple rules
         const rules = key[1]
           .split(';')
@@ -178,19 +173,4 @@ function keyframeStringToJSObject(keyframeString) {
       // combine array of keyframes into a single object
       .reduce((keySet, keyframe) => Object.assign(keySet, keyframe), {})
   );
-=======
-      // handle multiple rules
-      const rules = key[1].split(';').map(rule => {
-        // return {prop: value} object
-        const prop = rule.split(':');
-        return {[prop[0]]: prop[1]};
-      })
-      .reduce((ruleSet, rule) => Object.assign(ruleSet, rule), {}); // combine array of rules into a single object
-
-      // return rules for current keyframe
-      return {[key[0]]: rules};
-    })
-    // combine array of keyframes into a single object
-    .reduce((keySet, keyframe) => Object.assign(keySet, keyframe), {});
->>>>>>> brushed the code to silence the linter:packages/styletron-client/src/styletron-client.js
 }

--- a/packages/styletron-core/src/__tests__/index.js
+++ b/packages/styletron-core/src/__tests__/index.js
@@ -54,7 +54,20 @@ test('test injection', t => {
     pseudo: ':hover',
   });
   t.equal(instance.getCache().pseudo[':hover'].display.none, 'e');
-  t.equal(instance.getCount(), 5, 'ends with 4 unique declarations');
+
+  const keyframes = {
+    '0%': {
+      borderBottom: '1px',
+    },
+    '100%': {
+      borderBottom: '10px',
+    },
+  };
+  instance.injectDeclaration({prop: 'animationName', val: keyframes});
+  t.equal(instance.getCache().keyframes[JSON.stringify(keyframes)], 'f');
+  t.equal(instance.getCache().animationName.f, 'f');
+
+  t.equal(instance.getCount(), 6, 'ends with 6 unique declarations');
   t.end();
 });
 

--- a/packages/styletron-core/src/__tests__/index.js
+++ b/packages/styletron-core/src/__tests__/index.js
@@ -55,7 +55,6 @@ test('test injection', t => {
   });
   t.equal(instance.getCache().pseudo[':hover'].display.none, 'e');
 
-<<<<<<< HEAD:packages/styletron-core/src/__tests__/index.js
   const keyframes = {
     '0%': {
       borderBottom: '1px',
@@ -64,9 +63,6 @@ test('test injection', t => {
       borderBottom: '10px',
     },
   };
-=======
-  const keyframes = {'0%': {'borderBottom': '1px'}, '100%': {'borderBottom': '10px'}};
->>>>>>> brushed the code to silence the linter:packages/styletron-core/src/test/index.js
   instance.injectDeclaration({prop: 'animationName', val: keyframes});
   t.equal(instance.getCache().keyframes[JSON.stringify(keyframes)], 'f');
   t.equal(instance.getCache().animationName.f, 'f');

--- a/packages/styletron-core/src/__tests__/index.js
+++ b/packages/styletron-core/src/__tests__/index.js
@@ -55,6 +55,7 @@ test('test injection', t => {
   });
   t.equal(instance.getCache().pseudo[':hover'].display.none, 'e');
 
+<<<<<<< HEAD:packages/styletron-core/src/__tests__/index.js
   const keyframes = {
     '0%': {
       borderBottom: '1px',
@@ -63,6 +64,9 @@ test('test injection', t => {
       borderBottom: '10px',
     },
   };
+=======
+  const keyframes = {'0%': {'borderBottom': '1px'}, '100%': {'borderBottom': '10px'}};
+>>>>>>> brushed the code to silence the linter:packages/styletron-core/src/test/index.js
   instance.injectDeclaration({prop: 'animationName', val: keyframes});
   t.equal(instance.getCache().keyframes[JSON.stringify(keyframes)], 'f');
   t.equal(instance.getCache().animationName.f, 'f');

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -12,6 +12,7 @@ class StyletronCore {
     this.cache = {
       media: {},
       pseudo: {},
+      keyframes: {},
     };
     this.prefix = prefix === '' ? false : prefix;
     this.uniqueCount = 0;
@@ -39,6 +40,17 @@ class StyletronCore {
     }
     if (!targetEntry[prop]) {
       targetEntry[prop] = {};
+    }
+    if (['animationName', 'animation-name'].indexOf(prop) >= 0) {
+      const stringVal = JSON.stringify(val);
+      let animationName = className;
+      if (target.keyframes.hasOwnProperty(stringVal)) {
+        animationName = target.keyframes[stringVal];
+      } else {
+        target.keyframes[stringVal] = animationName;
+      }
+      targetEntry[prop][animationName] = className;
+      return;
     }
     targetEntry[prop][val] = className;
   }
@@ -105,6 +117,13 @@ class StyletronCore {
       if (!entry) {
         return false;
       }
+    }
+    if (['animationName', 'animation-name'].indexOf(prop) >= 0) {
+      const stringValue = JSON.stringify(val);
+      val =
+        this.cache.keyframes &&
+        this.cache.keyframes.hasOwnProperty(stringValue) &&
+        this.cache.keyframes[stringValue];
     }
     return entry[prop] && entry[prop].hasOwnProperty(val) && entry[prop][val];
   }

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -103,8 +103,7 @@ class StyletronCore {
    * @private
    */
   getCachedDeclaration({prop, val, media, pseudo}) {
-    let entry,
-        value = val;
+    let entry;
     if (media) {
       entry = this.cache.media[media];
       if (!entry) {
@@ -121,16 +120,12 @@ class StyletronCore {
     }
     if (['animationName', 'animation-name'].indexOf(prop) >= 0) {
       const stringValue = JSON.stringify(val);
-<<<<<<< HEAD
       val =
         this.cache.keyframes &&
         this.cache.keyframes.hasOwnProperty(stringValue) &&
         this.cache.keyframes[stringValue];
-=======
-        value = this.cache.keyframes && this.cache.keyframes.hasOwnProperty(stringValue) && this.cache.keyframes[stringValue];
->>>>>>> brushed the code to silence the linter
     }
-    return entry[prop] && entry[prop].hasOwnProperty(value) && entry[prop][value];
+    return entry[prop] && entry[prop].hasOwnProperty(val) && entry[prop][val];
   }
 }
 

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -103,7 +103,8 @@ class StyletronCore {
    * @private
    */
   getCachedDeclaration({prop, val, media, pseudo}) {
-    let entry;
+    let entry,
+        value = val;
     if (media) {
       entry = this.cache.media[media];
       if (!entry) {
@@ -120,12 +121,16 @@ class StyletronCore {
     }
     if (['animationName', 'animation-name'].indexOf(prop) >= 0) {
       const stringValue = JSON.stringify(val);
+<<<<<<< HEAD
       val =
         this.cache.keyframes &&
         this.cache.keyframes.hasOwnProperty(stringValue) &&
         this.cache.keyframes[stringValue];
+=======
+        value = this.cache.keyframes && this.cache.keyframes.hasOwnProperty(stringValue) && this.cache.keyframes[stringValue];
+>>>>>>> brushed the code to silence the linter
     }
-    return entry[prop] && entry[prop].hasOwnProperty(val) && entry[prop][val];
+    return entry[prop] && entry[prop].hasOwnProperty(value) && entry[prop][value];
   }
 }
 

--- a/packages/styletron-server/src/__tests__/index.js
+++ b/packages/styletron-server/src/__tests__/index.js
@@ -29,7 +29,7 @@ test('test getStylesheets method', t => {
   instance.setCache(fixtures.basic.cache);
   t.deepEqual(instance.getStylesheets(), [
     {
-      css: '.e:hover{display:none}.a{color:red}.b{color:green}',
+      css: '@keyframes f{0%{border-bottom:1px;margin-left:0}100%{border-bottom:10px;margin-left:10px}}.e:hover{display:none}.a{color:red}.b{color:green}.f{animation-name:f}',
     },
     {
       media: '(max-width: 800px)',
@@ -44,7 +44,7 @@ test('test getStylesheetsHtml method', t => {
   instance.setCache(fixtures.basic.cache);
   t.equal(
     instance.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.e:hover{display:none}.a{color:red}.b{color:green}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.d:hover{color:green}.c{color:green}</style>'
+    '<style class="_styletron_hydrate_">@keyframes f{0%{border-bottom:1px;margin-left:0}100%{border-bottom:10px;margin-left:10px}}.e:hover{display:none}.a{color:red}.b{color:green}.f{animation-name:f}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.d:hover{color:green}.c{color:green}</style>'
   );
   t.end();
 });

--- a/packages/styletron-server/src/base-obj-to-css.js
+++ b/packages/styletron-server/src/base-obj-to-css.js
@@ -1,17 +1,26 @@
 export default baseHandler;
 
 function baseHandler(key, valueObj) {
-  return key === 'pseudo'
-    ? pseudoObjToCss(valueObj)
-    : valsObjToCss(key, valueObj);
+  switch (key) {
+    case 'keyframes':
+      return keyframeObjToCss(valueObj);
+    case 'pseudo':
+      return pseudoObjToCss(valueObj);
+    default:
+      return valsObjToCss(key, valueObj);
+  }
 }
 
 function pseudoObjToCss(pseudoObj) {
   let css = '';
   for (const pseudoClass in pseudoObj) {
-    const propsObj = pseudoObj[pseudoClass];
-    for (const prop in propsObj) {
-      css += valsObjToCss(prop, propsObj[prop], pseudoClass);
+    if (pseudoObj.hasOwnProperty(pseudoClass)) {
+      const propsObj = pseudoObj[pseudoClass];
+      for (const prop in propsObj) {
+        if (propsObj.hasOwnProperty(prop)) {
+          css += valsObjToCss(prop, propsObj[prop], pseudoClass);
+        }
+      }
     }
   }
   return css;
@@ -20,8 +29,10 @@ function pseudoObjToCss(pseudoObj) {
 function valsObjToCss(prop, valsObj, pseudo) {
   let css = '';
   for (const val in valsObj) {
-    const className = valsObj[val];
-    css += declToCss(prop, val, className, pseudo);
+    if (valsObj.hasOwnProperty(val)) {
+      const className = valsObj[val];
+      css += declToCss(prop, val, className, pseudo);
+    }
   }
   return css;
 }
@@ -29,4 +40,31 @@ function valsObjToCss(prop, valsObj, pseudo) {
 function declToCss(prop, val, className, pseudo) {
   const classString = pseudo ? `${className}${pseudo}` : className;
   return `.${classString}{${prop}:${val}}`;
+}
+
+function keyframeObjToCss(keyframeObj) {
+  let css = '';
+  for (let keyframes in keyframeObj) {
+    if (keyframeObj.hasOwnProperty(keyframes)) {
+      css += `@keyframes ${keyframeObj[keyframes]}{`;
+
+      keyframes = JSON.parse(keyframes);
+      for (const key in keyframes) {
+        if (keyframes.hasOwnProperty(key)) {
+          css += `${key}{`;
+          for (const prop in keyframes[key]) {
+            if (keyframes[key].hasOwnProperty(prop)) {
+              css += `${prop}:${keyframes[key][prop]};`;
+            }
+          }
+          css = css.slice(0, -1);
+          css += '}';
+        }
+      }
+
+      css += '}';
+    }
+  }
+
+  return css;
 }

--- a/packages/styletron-server/src/base-obj-to-css.js
+++ b/packages/styletron-server/src/base-obj-to-css.js
@@ -49,10 +49,17 @@ function keyframeObjToCss(keyframeObj) {
       css += `@keyframes ${keyframeObj[keyframes]}{`;
 
       keyframes = JSON.parse(keyframes);
+<<<<<<< HEAD
       for (const key in keyframes) {
         if (keyframes.hasOwnProperty(key)) {
           css += `${key}{`;
           for (const prop in keyframes[key]) {
+=======
+      for (let key in keyframes) {
+        if (keyframes.hasOwnProperty(key)) {
+          css += `${key}{`;
+          for (let prop in keyframes[key]) {
+>>>>>>> brushed the code to silence the linter
             if (keyframes[key].hasOwnProperty(prop)) {
               css += `${prop}:${keyframes[key][prop]};`;
             }

--- a/packages/styletron-server/src/base-obj-to-css.js
+++ b/packages/styletron-server/src/base-obj-to-css.js
@@ -49,17 +49,10 @@ function keyframeObjToCss(keyframeObj) {
       css += `@keyframes ${keyframeObj[keyframes]}{`;
 
       keyframes = JSON.parse(keyframes);
-<<<<<<< HEAD
       for (const key in keyframes) {
         if (keyframes.hasOwnProperty(key)) {
           css += `${key}{`;
           for (const prop in keyframes[key]) {
-=======
-      for (let key in keyframes) {
-        if (keyframes.hasOwnProperty(key)) {
-          css += `${key}{`;
-          for (let prop in keyframes[key]) {
->>>>>>> brushed the code to silence the linter
             if (keyframes[key].hasOwnProperty(prop)) {
               css += `${prop}:${keyframes[key][prop]};`;
             }

--- a/packages/test-fixtures/basic.css
+++ b/packages/test-fixtures/basic.css
@@ -1,1 +1,1 @@
-.e:hover{display:none}.a{color:red}.b{color:green}@media (max-width: 800px){.d:hover{color:green}.c{color:green}}
+@keyframes f{0%{border-bottom:1px;margin-left:0}100%{border-bottom:10px;margin-left:10px}}.e:hover{display:none}.a{color:red}.b{color:green}.f{animation-name:f}@media (max-width: 800px){.d:hover{color:green}.c{color:green}}

--- a/packages/test-fixtures/basic.js
+++ b/packages/test-fixtures/basic.js
@@ -1,4 +1,7 @@
 module.exports = {
+  keyframes: {
+    '{"0%":{"border-bottom":"1px","margin-left":"0"},"100%":{"border-bottom":"10px","margin-left":"10px"}}': 'f',
+  },
   media: {
     '(max-width: 800px)': {
       pseudo: {
@@ -23,5 +26,8 @@ module.exports = {
   color: {
     red: 'a',
     green: 'b',
+  },
+  'animation-name': {
+    f: 'f',
   },
 };

--- a/packages/test-fixtures/multiple-media.js
+++ b/packages/test-fixtures/multiple-media.js
@@ -1,4 +1,5 @@
 module.exports = {
+  keyframes: {},
   media: {
     '(max-width: 800px)': {
       pseudo: {

--- a/packages/test-fixtures/simple.js
+++ b/packages/test-fixtures/simple.js
@@ -1,4 +1,5 @@
 module.exports = {
+  keyframes: {},
   media: {
     '(max-width: 333px)': {
       pseudo: {},


### PR DESCRIPTION
Ref. #92

**NOTE:** This is still in development. While it does work, it has some drawbacks. Please read below. Thanks!

### Changes

- Added a new key to the cache object called `keyframes`. This object will hold our animations.
- Since keyframe animations cannot be combined as normal classes are, the keys of this new object are the json stringified versions of the animation objects, while the values represent the generated animation names. This way, identical animation objects will have the same generated name.
- A class name is also added with the new animation-name. To keep things simple, the animation name and the class name are the same.

### Usage:

```js
const Box = styled('div', {
    animationName: {
        '0%': {
            'margin-top': 0
        },
        '100%': {
            'margin-top': '100px'
        }
    }
});
```

### Known issues

- CamelCase support is not fully implemented; use `'margin-top'` rules instead of `maginTop`
- Shorthand `animation` is not implemented. This will require a helper function that would retrieve an animation name based on a given rule set object.
- String value for animationName is not supported.
- Vendor prefixes for `@keyframes {...}` are not implemented.
- Theoretically, this should also work with media queries. But I haven't tested it yet.
