### PR TITLE
Build modules with rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ npm-debug.log
 npm-debug.log.*
 htmldocs/
 lerna-debug.log
+yarn-error.log
 lib/
+dist/

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
     "rimraf": "^2.5.4",
+    "rollup": "^0.41.6",
+    "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^2.0.0",
     "tape": "^4.6.0",
     "unitest": "^1.0.0"
   },

--- a/packages/styletron-client-ie9/package.json
+++ b/packages/styletron-client-ie9/package.json
@@ -6,12 +6,14 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/styletron-client-ie9.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "../../node_modules/.bin/unitest --browser=lib/test/browser.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {
     "styletron-client": "^2.5.1"

--- a/packages/styletron-client-ie9/rollup.config.js
+++ b/packages/styletron-client-ie9/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/styletron-client-ie9.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-client-ie9/rollup.config.js
+++ b/packages/styletron-client-ie9/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/styletron-client-ie9.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-client-ie9/rollup.config.js
+++ b/packages/styletron-client-ie9/rollup.config.js
@@ -6,7 +6,8 @@ export default {
   entry: 'src/styletron-client-ie9.js',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
-    { dest: 'dist/bundle.es.js', format: 'es'}
+    { dest: 'dist/bundle.es.js', format: 'es'},
+    { dest: 'dist/bundle.umd.js', format: 'umd', moduleName: 'StyletronClient'}
   ],
   plugins: [
     nodeResolve(),

--- a/packages/styletron-client/package.json
+++ b/packages/styletron-client/package.json
@@ -6,13 +6,15 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/styletron-client.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "types": "./index.d.ts",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "../../node_modules/.bin/unitest --browser=lib/test/browser.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {
     "styletron-core": "^2.5.1"

--- a/packages/styletron-client/rollup.config.js
+++ b/packages/styletron-client/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/styletron-client.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-client/rollup.config.js
+++ b/packages/styletron-client/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/styletron-client.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-client/rollup.config.js
+++ b/packages/styletron-client/rollup.config.js
@@ -6,7 +6,8 @@ export default {
   entry: 'src/styletron-client.js',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
-    { dest: 'dist/bundle.es.js', format: 'es'}
+    { dest: 'dist/bundle.es.js', format: 'es'},
+    { dest: 'dist/bundle.umd.js', format: 'umd', moduleName: 'StyletronClient'}
   ],
   plugins: [
     nodeResolve(),

--- a/packages/styletron-core/package.json
+++ b/packages/styletron-core/package.json
@@ -6,13 +6,15 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/index.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "types": "./index.d.ts",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "node lib/test/index.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/styletron-core/rollup.config.js
+++ b/packages/styletron-core/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/index.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-core/rollup.config.js
+++ b/packages/styletron-core/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/index.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-inferno/package.json
+++ b/packages/styletron-inferno/package.json
@@ -6,12 +6,14 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/index.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "../../node_modules/.bin/unitest --browser=lib/test/browser.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {
     "styletron-client": "^2.5.1",

--- a/packages/styletron-inferno/rollup.config.js
+++ b/packages/styletron-inferno/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/index.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-inferno/rollup.config.js
+++ b/packages/styletron-inferno/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/index.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -6,13 +6,15 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/index.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "types": "./index.d.ts",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "../../node_modules/.bin/unitest --browser=lib/test/browser.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {
     "@types/react": "*",

--- a/packages/styletron-react/rollup.config.js
+++ b/packages/styletron-react/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/index.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-react/rollup.config.js
+++ b/packages/styletron-react/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/index.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-utils/package.json
+++ b/packages/styletron-utils/package.json
@@ -6,16 +6,17 @@
   "homepage": "https://github.com/rtsao/styletron",
   "repository": "git@github.com:rtsao/styletron.git",
   "bugs": "https://github.com/rtsao/styletron/issues",
-  "main": "./lib/index.js",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.es.js",
   "scripts": {
     "transpile": "../../node_modules/.bin/buble -i src -o lib",
+    "bundle": "../../node_modules/.bin/rollup -c",
     "pretest": "npm run transpile",
     "test": "node lib/test/index.js",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run bundle"
   },
   "dependencies": {
     "inline-style-prefixer": "^2.0.1"
   },
-  "devDependencies": {},
   "license": "MIT"
 }

--- a/packages/styletron-utils/rollup.config.js
+++ b/packages/styletron-utils/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/index.js',
+  format: 'cjs',
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs'},
+    { dest: 'dist/bundle.es.js', format: 'es'}
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    buble()
+  ]
+};

--- a/packages/styletron-utils/rollup.config.js
+++ b/packages/styletron-utils/rollup.config.js
@@ -4,7 +4,6 @@ import buble from 'rollup-plugin-buble';
 
 export default {
   entry: 'src/index.js',
-  format: 'cjs',
   targets: [
     { dest: 'dist/bundle.cjs.js', format: 'cjs'},
     { dest: 'dist/bundle.es.js', format: 'es'}

--- a/packages/styletron-utils/yarn.lock
+++ b/packages/styletron-utils/yarn.lock
@@ -16,3 +16,19 @@ inline-style-prefixer@^2.0.1:
   dependencies:
     bowser "^1.0.0"
     hyphenate-style-name "^1.0.1"
+
+rollup@^0.41.6:
+  version "0.41.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+  dependencies:
+    source-map-support "^0.4.0"
+
+source-map-support@^0.4.0:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
+  dependencies:
+    source-map "^0.5.6"
+
+source-map@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@ acorn-object-spread@^1.0.0:
   dependencies:
     acorn "^3.1.0"
 
-acorn@4.0.4:
+acorn@4.0.4, acorn@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
@@ -57,6 +57,16 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  dependencies:
+    arr-flatten "^1.0.1"
+
+arr-flatten@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -70,6 +80,10 @@ array-union@^1.0.1:
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
 arrify@^1.0.0:
   version "1.0.1"
@@ -155,6 +169,20 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
 buble@^0.15.0:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
@@ -171,7 +199,7 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -601,6 +629,14 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -620,6 +656,18 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  dependencies:
+    fill-range "^2.1.0"
+
 extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
@@ -629,6 +677,12 @@ external-editor@^2.0.1:
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.1.tgz#4c597c6c88fa6410e41dbbaa7b1be2336aa31095"
   dependencies:
     tmp "^0.0.31"
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  dependencies:
+    is-extglob "^1.0.0"
 
 extract-zip@^1.0.3:
   version "1.6.0"
@@ -685,6 +739,20 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+filename-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
+
+fill-range@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^1.1.3"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -706,6 +774,16 @@ for-each@~0.3.2:
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
   dependencies:
     is-function "~1.0.0"
+
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -764,6 +842,19 @@ getpass@^0.1.1:
 getport@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  dependencies:
+    is-glob "^2.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@~7.1.1:
   version "7.1.1"
@@ -930,6 +1021,10 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-buffer@^1.0.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
@@ -943,6 +1038,24 @@ is-callable@^1.1.1, is-callable@^1.1.3:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-dotfile@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  dependencies:
+    is-primitive "^2.0.0"
+
+is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -964,6 +1077,12 @@ is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  dependencies:
+    is-extglob "^1.0.0"
+
 is-my-json-valid@^2.10.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
@@ -972,6 +1091,12 @@ is-my-json-valid@^2.10.0:
     generate-object-property "^1.1.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-number@^2.0.2, is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -988,6 +1113,14 @@ is-path-inside@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -1029,13 +1162,19 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@^1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
 isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  dependencies:
+    isarray "1.0.0"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
@@ -1131,6 +1270,12 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+kind-of@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
+  dependencies:
+    is-buffer "^1.0.2"
+
 klaw@^1.0.0, klaw@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -1209,6 +1354,12 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
+magic-string@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.0.tgz#198948217254e3e0b93080e01146b7c73b2a06b2"
+  dependencies:
+    vlq "^0.2.1"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -1235,6 +1386,24 @@ meow@^3.1.0, meow@^3.7.0:
 merge2@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.0.3.tgz#fa44f8b2262615ab72f0808a401d478a70e394db"
+
+micromatch@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  dependencies:
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
 
 mime-db@~1.26.0:
   version "1.26.0"
@@ -1361,6 +1530,13 @@ object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -1395,6 +1571,15 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
 os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -1462,6 +1647,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
 pretty-bytes@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
@@ -1507,6 +1696,13 @@ push-dir@^0.4.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+randomatic@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
+  dependencies:
+    is-number "^2.0.2"
+    kind-of "^3.0.2"
 
 rc@^1.1.2:
   version "1.1.7"
@@ -1614,6 +1810,21 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+regex-cache@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  dependencies:
+    is-equal-shallow "^0.1.3"
+    is-primitive "^2.0.0"
+
+repeat-element@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+
+repeat-string@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -1664,7 +1875,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.6, resolve@~1.1.7:
+resolve@1.1.7, resolve@^1.1.6, resolve@^1.1.7, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
@@ -1693,6 +1904,51 @@ rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.4:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rollup-plugin-buble@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-buble/-/rollup-plugin-buble-0.15.0.tgz#83c3e89c7fd2266c7918f41ba3980313519c7fd0"
+  dependencies:
+    buble "^0.15.0"
+    rollup-pluginutils "^1.5.0"
+
+rollup-plugin-commonjs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz#98b1589bfe32a6c0f67790b60c0b499972afed89"
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.0.0.tgz#07e0ae94ac002a3ea36e8f33ca121d9f836b1309"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    resolve "^1.1.6"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup@^0.41.6:
+  version "0.41.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+  dependencies:
+    source-map-support "^0.4.0"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -1761,6 +2017,16 @@ sntp@1.x.x:
 sorted-object@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/sorted-object/-/sorted-object-2.0.1.tgz#7d631f4bd3a798a24af1dffcfbfe83337a5df5fc"
+
+source-map-support@^0.4.0:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
+  dependencies:
+    source-map "^0.5.6"
+
+source-map@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 spdx-correct@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Part of #98 . I’ve left styletron and styletron singleton alone as I was not sure it was worthwhile to convert them. I also added a UMD bundle for styletron client and styletron-client-ie9.

I still need to test that importing the modules in a project works. Maybe in the end it would make sense to test the bundles, as I did not find tests that exercise private modules.