### PR TITLE
Move `prop-types` to `dependencies`

### DIFF
--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -24,8 +24,5 @@
   "peerDependencies": {
     "react": "0.14.x - 15.x"
   },
-  "devDependencies": {
-    "styletron-server": "^2.5.1"
-  },
   "license": "MIT"
 }

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "@types/react": "*",
+    "prop-types": "^15.5.8",
     "styletron-client": "^2.5.1",
     "styletron-server": "^2.5.1",
     "styletron-utils": "^2.5.4"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.8",
     "react": "0.14.x - 15.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Per [recommendation by `prop-types`](https://github.com/reactjs/prop-types/blob/master/README.md#how-to-depend-on-this-package) it should be a dependency and not a peer dependency.