### PR TITLE
TypeScript typing tests and reflect the return type of `styled` as stateless component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
   - lerna bootstrap --ignore={benchmarks,demos} --concurrency=1
   - lerna run pretest --ignore={benchmarks,demos}
   - lerna run test --ignore={benchmarks,demos} --concurrency=1
+  - yarn run tsc

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "lint": "eslint packages/*/src/**",
+    "tsc": "tsc",
     "build-docs": "jsdoc -c jsdoc.json",
-    "pretest": "npm run lint && lerna run pretest",
+    "pretest": "npm run lint && npm run tsc && lerna run pretest",
     "test": "lerna run test --concurrency=1",
     "predeploy-docs": "rimraf htmldocs && npm run build-docs && echo styletron.js.org > htmldocs/CNAME",
     "deploy-docs": "push-dir --dir htmldocs --branch gh-pages"
@@ -30,6 +31,7 @@
     "react-dom": "^15.5.4",
     "rimraf": "^2.5.4",
     "tape": "^4.6.0",
+    "typescript": "^2.3.2",
     "unitest": "^1.0.0"
   },
   "license": "MIT"

--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -15,17 +15,7 @@ declare namespace StyletronReact {
 
   type Style<TProps> = React.CSSProperties | StyleFunction<TProps>;
 
-  class CStyledHTMLElement<TProps, TElement extends HTMLElement> extends React.Component<TProps & React.HTMLAttributes<TElement> & InnerRef<TElement>, void> {
-    // We define the render method to force a difference between all styled
-    // components, otherwise TypeScript thinks that any component passed as
-    // base argument to `styled` is a `StyledHTMLElement` since it's the first
-    // one matching
-    render(): React.DOMElement<React.HTMLAttributes<TElement>, TElement>
-  }
-
-  interface StyledHTMLElement<TProps, TElement extends HTMLElement> {
-    new (): CStyledHTMLElement<TProps, TElement>;
-  }
+  interface StyledHTMLElement<TProps, TElement extends HTMLElement> extends React.StatelessComponent<TProps & React.HTMLAttributes<TElement> & InnerRef<TElement>> {}
 
   export function styled<TElement extends HTMLElement, TProps>(base: string, style: Style<TProps>): StyledHTMLElement<TProps, TElement>;
   export function styled<TElement extends HTMLElement, TProps, TBaseProps>(base: StyledHTMLElement<TBaseProps, TElement>, style: Style<TProps>): StyledHTMLElement<TBaseProps & TProps, TElement>;
@@ -145,13 +135,7 @@ declare namespace StyletronReact {
   export function styled<TProps>(base: "video", style: Style<TProps>): StyledHTMLElement<TProps, HTMLVideoElement>;
   export function styled<TProps>(base: "wbr", style: Style<TProps>): StyledHTMLElement<TProps, HTMLElement>;
 
-  class CStyledSVGElement<TProps, TElement extends SVGElement> extends React.Component<TProps & React.SVGAttributes<TElement> & InnerRef<TElement>, void> {
-    render(): React.DOMElement<React.HTMLAttributes<TElement>, TElement>
-  }
-
-  interface StyledSVGElement<TProps, TElement extends SVGElement> {
-    new (): CStyledSVGElement<TProps, TElement>;
-  }
+  interface StyledSVGElement<TProps, TElement extends SVGElement> extends React.StatelessComponent<TProps & React.SVGAttributes<TElement> & InnerRef<TElement>> {}
 
   export function styled<TElement extends SVGElement, TProps>(base: string, style: Style<TProps>): StyledSVGElement<TProps, TElement>;
   export function styled<TElement extends SVGElement, TProps, TBaseProps>(base: StyledSVGElement<TBaseProps, TElement>, style: Style<TProps>): StyledSVGElement<TBaseProps & TProps, TElement>;
@@ -210,26 +194,14 @@ declare namespace StyletronReact {
   export function styled<TProps>(base: "use", style: Style<TProps>): StyledSVGElement<TProps, SVGElement>;
   export function styled<TProps>(base: "view", style: Style<TProps>): StyledSVGElement<TProps, SVGElement>;
 
-  class CStyledStatelessComponent<TProps> extends React.Component<TProps, void> {
-    render(): React.SFCElement<TProps>
-  }
-
-  interface StyledStatelessComponent<TProps> {
-    new (): CStyledStatelessComponent<TProps>;
-  }
+  interface StyledStatelessComponent<TProps> extends React.StatelessComponent<TProps> {}
 
   export function styled<TProps>(
     base: React.StatelessComponent<TProps> | StyledStatelessComponent<TProps>,
     style: Style<TProps>
   ): StyledStatelessComponent<TProps>;
 
-  class CStyledComponentClass<TProps, TComponent extends React.Component<TProps, React.ComponentState>> extends React.Component<TProps & InnerRef<TComponent>, void> {
-    render(): React.ComponentElement<TProps, TComponent>
-  }
-
-  interface StyledComponentClass<TProps, TComponent extends React.Component<TProps, React.ComponentState>> {
-    new (): CStyledComponentClass<TProps, TComponent>;
-  }
+  interface StyledComponentClass<TProps, TComponent extends React.Component<TProps, React.ComponentState>> extends React.StatelessComponent<TProps & InnerRef<TComponent>> {}
 
   export function styled<TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
     base: StyledComponentClass<TProps, TComponent>,

--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -6,7 +6,7 @@ declare namespace StyletronReact {
   export class StyletronProvider extends React.Component<{styletron: StyletronServer | StyletronClient}, void> {}
 
   type InnerRef<TInstance> = {
-    innerRef?: (instance: TInstance) => any;
+    innerRef?: React.Ref<TInstance>;
   };
 
   // Intersecting `CSSProperties` enables autocompletion for CSS properties as

--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -11,7 +11,7 @@ declare namespace StyletronReact {
 
   // Intersecting `CSSProperties` enables autocompletion for CSS properties as
   // plain objects and not only for function return objects
-  type StyleFunction<TProps> = React.CSSProperties & ((props: TProps) => React.CSSProperties);
+  type StyleFunction<TProps> = React.CSSProperties & ((props: TProps, context?: any) => React.CSSProperties);
 
   type Style<TProps> = React.CSSProperties | StyleFunction<TProps>;
 

--- a/packages/styletron-react/typecheck.tsx
+++ b/packages/styletron-react/typecheck.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import {
+  styled,
+  StyledHTMLElement,
+  StyledSVGElement,
+  StyledStatelessComponent,
+  StyledComponentClass,
+} from './';
+
+type PropType = {
+  prop: boolean;
+};
+
+
+const PrettyHtmlElement: StyledHTMLElement<PropType, HTMLDivElement> = styled('div', (props: PropType) => ({}));
+
+<PrettyHtmlElement prop={false} className="" innerRef={(el: HTMLDivElement) => {}} />
+
+const ComposedHtmlElement: StyledHTMLElement<PropType, HTMLDivElement> = styled(PrettyHtmlElement, {});
+
+<ComposedHtmlElement prop={false} className="" innerRef={(el: HTMLDivElement) => {}} />
+
+
+const PrettySvgElement: StyledSVGElement<PropType, SVGElement> = styled('svg', (props: PropType) => ({}));
+
+<PrettySvgElement prop={false} className="" innerRef={(el: SVGElement) => {}} />
+
+const ComposedSvgElement: StyledSVGElement<PropType, SVGElement> = styled(PrettySvgElement, {});
+
+<ComposedSvgElement prop={false} className="" innerRef={(el: SVGElement) => {}} />
+
+
+function StatelessComponent(props: PropType) {
+  return <div />;
+}
+
+const PrettyStatelessComponentWithStyleFunc: StyledStatelessComponent<PropType> = styled(StatelessComponent, (props: PropType) => ({}));
+
+<PrettyStatelessComponentWithStyleFunc prop={false} />
+
+const PrettyStatelessComponentWithStyleObject: StyledStatelessComponent<PropType> = styled(StatelessComponent, {});
+
+<PrettyStatelessComponentWithStyleObject prop={false} />
+
+const ComposedStatelessComponent: StyledStatelessComponent<PropType> = styled(PrettyStatelessComponentWithStyleFunc, {});
+
+<ComposedStatelessComponent prop={false} />
+
+
+class StatefullComponent extends React.Component<PropType, void> {
+  render() {
+    return <div />;
+  }
+}
+
+const PrettyStatefullComponentWithStyleFunc: StyledComponentClass<PropType, StatefullComponent> = styled(StatefullComponent, (props: PropType) => ({}));
+
+<PrettyStatefullComponentWithStyleFunc prop={false} innerRef={(c: StatefullComponent) => {}} />
+
+const PrettyStatefullComponentWithStyleObject: StyledComponentClass<PropType, StatefullComponent> = styled(StatefullComponent, {});
+
+<PrettyStatefullComponentWithStyleObject prop={false} innerRef={(c: StatefullComponent) => {}} />
+
+const ComposedStatefullComponent: StyledComponentClass<PropType, StatefullComponent> = styled(PrettyStatefullComponentWithStyleFunc, {});
+
+<ComposedStatefullComponent prop={false} innerRef={(c: StatefullComponent) => {}} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "jsx": "preserve"
+    },
+    "include": [
+        "packages/*/*.ts",
+        "packages/*/*.tsx"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,6 +2656,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"


### PR DESCRIPTION
Thanks to https://github.com/rtsao/styletron/commit/0ec7c18829053b59db387c6d0674f8407a736250 we can remove the hack for some reason and extend the official `React.StatelessComponent` which gives the users a truthful return type of `styled`.

I also added a simple typings test.