### PR TITLE
[WIP] `withStyle` HOC

### DIFF
--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -10,53 +10,66 @@ declare namespace StyletronReact {
 
   export function styled<TProps>(
     base: React.StatelessComponent<TProps & ClassNameProp>,
-    style: Style<TProps>): Component<TProps>;
+    style: Style<TProps, React.CSSProperties>): Component<TProps>;
 
   export function styled<TInnerProps, TOuterProps>(
     base: React.StatelessComponent<TInnerProps & ClassNameProp>,
-    style: Style<TOuterProps>): Component<TOuterProps & TInnerProps>;
+    style: Style<TOuterProps, React.CSSProperties>): Component<TOuterProps & TInnerProps>;
 
   export function styled<TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
     base: React.ClassType<TProps, TComponent, React.ComponentClass<TProps & ClassNameProp>>,
-    style: Style<TProps>): Component<ClassProps<TProps, TComponent>>;
+    style: Style<TProps, React.CSSProperties>): Component<ClassProps<TProps, TComponent>>;
 
   export function styled<TProps, TBase extends keyof BasePropsMap<TProps>>(
     base: TBase,
-    style: Style<TProps>): Component<BasePropsMap<TProps>[TBase]>;
+    style: Style<TProps, React.CSSProperties>): Component<BasePropsMap<TProps>[TBase]>;
 
   export function styled<TElement extends HTMLElement, TProps>(
     base: string,
-    style: Style<TProps>): Component<HTMLProps<TProps, TElement>>;
+    style: Style<TProps, React.CSSProperties>): Component<HTMLProps<TProps, TElement>>;
 
   export function styled<TElement extends SVGElement, TProps>(
     base: string,
-    style: Style<TProps>): Component<SVGProps<TProps, TElement>>;
+    style: Style<TProps, React.CSSProperties>): Component<SVGProps<TProps, TElement>>;
 
   type ClassNameProp = {className?: string};
 
+  export function withStyle<TStyles extends MultiStyle>(styles: StyleFunction<{}, TStyles>): Decorator<TStyles>
+  export function withStyle<TStyles extends MultiStyle>(styles: TStyles): Decorator<TStyles>
+
+  type Decorator<TStyles> = {
+    <TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
+      base: React.ClassType<TProps, TComponent, React.ComponentClass<TProps & ClassesProp<TStyles>>>): Component<ClassProps<TProps, TComponent>>
+    <TProps>(base: React.StatelessComponent<TProps & ClassesProp<TStyles>>): Component<TProps>
+  }
+
+  type ClassesProp<TStyles> = {classes: {[K in keyof TStyles]: string}};
+
+  type MultiStyle = {[name: string]: React.CSSProperties};
+
   export function core<TOuterProps, TInnerProps>(
     base: React.StatelessComponent<TInnerProps>,
-    style: Style<TOuterProps>,
+    style: Style<TOuterProps, React.CSSProperties>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<TOuterProps>;
 
   export function core<TOuterProps, TInnerProps, TComponent extends React.Component<TInnerProps, React.ComponentState>>(
     base: React.ClassType<TInnerProps, TComponent, React.ComponentClass<TInnerProps>>,
-    style: Style<TOuterProps>,
+    style: Style<TOuterProps, React.CSSProperties>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<ClassProps<TOuterProps, TComponent>>;
 
   export function core<TOuterProps, TInnerProps, TBase extends keyof BasePropsMap<TInnerProps>>(
     base: TBase,
-    style: Style<TOuterProps>,
+    style: Style<TOuterProps, React.CSSProperties>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<BasePropsMap<TOuterProps>[TBase]>;
 
   export function core<TElement extends HTMLElement, TOuterProps, TInnerProps>(
     base: string,
-    style: Style<TOuterProps>,
+    style: Style<TOuterProps, React.CSSProperties>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<HTMLProps<TOuterProps, TElement>>;
 
   export function core<TElement extends SVGElement, TOuterProps, TInnerProps>(
     base: string,
-    style: Style<TOuterProps>,
+    style: Style<TOuterProps, React.CSSProperties>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<SVGProps<TOuterProps, TElement>>;
 
   type Component<TProps> = React.StatelessComponent<TProps>;
@@ -73,11 +86,10 @@ declare namespace StyletronReact {
 
   type AssignProps<TOuterProps, TInnerProps> = (styletron: StyletronServer | StyletronClient, style: React.CSSProperties, props?: TOuterProps) => TInnerProps;
 
-  type Style<TProps> = React.CSSProperties | StyleFunction<TProps>;
+  // Intersecting `TCSS` with `StyleFunction` enables autocompletion
+  type Style<TProps, TCSS> = TCSS | (TCSS & StyleFunction<TProps, TCSS>);
 
-  // Intersecting `CSSProperties` enables autocompletion for CSS properties as
-  // plain objects and not only for function return objects
-  type StyleFunction<TProps> = React.CSSProperties & ((props: TProps, context?: any) => React.CSSProperties);
+  type StyleFunction<TProps, TCSS> = (props: TProps, context?: any) => TCSS;
 
   interface BasePropsMap<TProps> {
     a: HTMLProps<TProps, HTMLAnchorElement>;

--- a/packages/styletron-react/src/__tests__/browser.js
+++ b/packages/styletron-react/src/__tests__/browser.js
@@ -8,6 +8,7 @@ import Styletron from 'styletron-server';
 import {injectStylePrefixed} from 'styletron-utils';
 import core from '../core';
 import styled from '../styled';
+import withStyle from '../with-style';
 import Provider from '../provider';
 
 function strictAssignProps(styletron, styleResult, ownProps) {
@@ -242,4 +243,32 @@ test('styled merges class name prop', t => {
   const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
   t.equal(div.className, 'foo a', 'matches expected classes');
   t.end();
+});
+
+test('with style passes props', t => {
+  t.plan(1);
+
+  class InnerComponent extends React.Component {
+    render() {
+      t.deepEqual(
+        this.props,
+        {classes: {foo: 'a'}, bar: 'baz'},
+        'matches props'
+      );
+      return <button>InnerComponent</button>;
+    }
+  }
+
+  const styletron = new Styletron();
+  const Widget = withStyle({foo: {color: 'red'}})(InnerComponent);
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(
+      Provider,
+      {styletron},
+      React.createElement(Widget, {
+        bar: 'baz',
+      })
+    )
+  );
 });

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -1,5 +1,6 @@
 import StyletronProvider from './provider';
 import core from './core';
 import styled from './styled';
+import withStyle from './with-style';
 
-export {StyletronProvider, core, styled};
+export {StyletronProvider, core, styled, withStyle};

--- a/packages/styletron-react/src/with-style.js
+++ b/packages/styletron-react/src/with-style.js
@@ -1,0 +1,15 @@
+import core from './core';
+import {injectStylePrefixed} from 'styletron-utils';
+
+export default function withStyle(styles) {
+  return Component => core(Component, styles, assignProps);
+}
+
+function assignProps(styletron, styleResult, ownProps) {
+  // Skipping cloning of `ownProps` since that's already done internally
+  const classes = (ownProps.classes = {});
+  for (const name in styleResult) {
+    classes[name] = injectStylePrefixed(styletron, styleResult[name]);
+  }
+  return ownProps;
+}

--- a/packages/styletron-react/typecheck.tsx
+++ b/packages/styletron-react/typecheck.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {
   core,
   styled,
+  withStyle,
+  ClassesProp,
 } from './';
 
 
@@ -77,6 +79,50 @@ const StyledStatefullComponentWithStyleObject = styled(StatefullComponent, {});
 const ComposedStatefullComponent = styled(StyledStatefullComponentWithStyleFunc, {});
 
 <ComposedStatefullComponent prop1={false} innerRef={(c: StatefullComponent) => {}} />
+
+
+const withStyleObject = {
+  a: {},
+  b: {},
+};
+
+type WithStyleObjectType = typeof withStyleObject;
+
+function StatelessWithStyle(props: PropType1 & ClassesProp<WithStyleObjectType>) {
+  return (
+    <div>
+      <span className={props.classes.a} />
+      <span className={props.classes.b} />
+    </div>
+  );
+}
+
+const MultiPrettyStatelessComponentWithStyleFunc = withStyle((props: PropType1) => withStyleObject)(StatelessWithStyle);
+
+<MultiPrettyStatelessComponentWithStyleFunc prop1={false} />
+
+const MultiPrettyStatelessComponentWithStyleObject = withStyle(withStyleObject)(StatelessWithStyle);
+
+<MultiPrettyStatelessComponentWithStyleObject prop1={false} />
+
+class StatefullWithStyle extends React.Component<PropType1 & ClassesProp<WithStyleObjectType>, void> {
+  render() {
+    return (
+      <div>
+        <span className={this.props.classes.a} />
+        <span className={this.props.classes.b} />
+      </div>
+    );
+  }
+}
+
+const MultiPrettyStatefullComponentWithStyleFunc = withStyle((props: PropType1) => withStyleObject)(StatefullWithStyle);
+
+<MultiPrettyStatefullComponentWithStyleFunc prop1={false} innerRef={(c: StatefullWithStyle) => {}} />
+
+const MultiPrettyStatefullWithStyleObject = withStyle(withStyleObject)(StatefullWithStyle);
+
+<MultiPrettyStatefullWithStyleObject prop1={false} innerRef={(c: StatefullWithStyle) => {}} />
 
 
 const PrettyHTMLElement = core(


### PR DESCRIPTION
Fixes #33.

A `withStyle` HOC function is highly requested and will become more natural to use with React v16 whereof it will be possible to render an array of children.

Today it's only possible to pass `className` to one element using `styled`:

```jsx
function MyComponent(props) {
  return <div className={props.className} />
}

const Pretty = styled(MyComponent, {color: 'red'});
```

Doing this with React16 will become weird. So this PR provides a `withStyle` HOC function:

```jsx
function MyComponent(props) {
  return [
    <div className={props.classes.a} />,
    <div className={props.classes.b} />,
    <div className={props.classes.c} />
  ]
}

const Pretty = withStyle({
  a: {color: 'red'},
  b: {color: 'green'},
  c: {color: 'blue'},
})(MyComponent);
```

## Problem

With `styled`, it's possible to compose a styled component:

```jsx
function MyComponent(props) {
  return <div className={props.className} />
}

const Pretty = styled(MyComponent, {color: 'red'});

const Composed = styled(Pretty , {background: 'black'});

/* Result:
{
  color: 'red',
  background: 'black'
}
```

The question here is how composition should be handled for `withStyle`.

```jsx
function MyComponent(props) {
  return [
    <div className={props.classes.a} />,
    <div className={props.classes.b} />,
    <div className={props.classes.c} />
  ]
}

const Pretty = withStyle({
  a: {color: 'red'},
  b: {color: 'green'},
  c: {color: 'blue'},
})(MyComponent);

const Composed = withStyle({
  b: {background: 'black'},
})(Pretty);

/* Result 1:
{
  a: {color: 'red'},
  b: {
    color: 'green',
    background: 'black'
  },
  c: {color: 'blue'},
} */

/* Result 2 (current):
{
  a: {color: 'red'},
  b: {background: 'black'},
  c: {color: 'blue'},
} */
```

Since `core` doesn't deep merge styles, it will override `b` with the new style. **If "Result 1" is to be expected, which is the best way to do that?** A simple solution would be to "just" deep merge styles, which would also solve `@media` and `:hover` overrides. But I guess there's a good reason it's not implemented in the first place:

```jsx
const Pretty = styled('div', {
  '@media (min-width: 768px)': {color: 'red'}
});

const Composed = styled(Pretty , {
  '@media (min-width: 768px)': {background: 'black'} // Will override `{color: 'red'}`
});
```