### PR TITLE
Collapse prefixed styles into one atomic class

### DIFF
--- a/packages/styletron-client/src/__tests__/browser.js
+++ b/packages/styletron-client/src/__tests__/browser.js
@@ -34,9 +34,8 @@ test('hydration basic', t => {
   const instance = new StyletronTest(elements);
   t.deepEqual(instance.getCache(), fixtures.basic.cache, 'cache hydrated');
   t.equal(instance.getUniqueDeclarationCount(), 5, 'count correctly hyrdated');
-  const newClass = instance.injectDeclaration({
-    prop: 'color',
-    val: 'purple',
+  const newClass = instance.injectRawDeclaration({
+    block: 'color:purple',
     media: '(max-width: 800px)',
   });
   t.equal(newClass, 'f', 'new class with correct count');
@@ -47,14 +46,14 @@ test('rule insertion order', t => {
   const element = createStyleElement('');
   const instance = new StyletronTest([element]);
   const decls = [
-    {prop: 'color', val: 'red'},
-    {prop: 'color', val: 'blue'},
-    {prop: 'color', val: 'blue', media: '(max-width: 333px)'},
-    {prop: 'color', val: 'green'},
-    {prop: 'color', val: 'red', media: 'screen and (max-width: 400px)'},
-    {prop: 'color', val: 'purple'},
+    {block: 'color:red'},
+    {block: 'color:blue'},
+    {block: 'color:blue', media: '(max-width: 333px)'},
+    {block: 'color:green'},
+    {block: 'color:red', media: 'screen and (max-width: 400px)'},
+    {block: 'color:purple'},
   ];
-  decls.forEach(decl => instance.injectDeclaration(decl));
+  decls.forEach(decl => instance.injectRawDeclaration(decl));
   t.equal(element.sheet.rules.length, 4);
   const mainExpected = [
     '.a { color: red; }',

--- a/packages/styletron-client/src/index.js
+++ b/packages/styletron-client/src/index.js
@@ -49,8 +49,7 @@ class StyletronClient extends StyletronCore {
     // {
     //  1: className,
     //  2: pseudo,
-    //  3: prop,
-    //  4: val
+    //  3: block,
     // }
     while ((decl = DECL_REGEX.exec(css))) {
       super.incrementVirtualCount();

--- a/packages/styletron-core/index.d.ts
+++ b/packages/styletron-core/index.d.ts
@@ -1,5 +1,6 @@
 declare class StyletronCore {
   injectDeclaration(decl: {prop: string; val: string; media?: string; pseudo?: string}): string | void;
+  injectRawDeclaration(decl: {block: string; media?: string; pseudo?: string}): string | void;
 }
 
 export default StyletronCore;

--- a/packages/styletron-core/src/__tests__/index.js
+++ b/packages/styletron-core/src/__tests__/index.js
@@ -20,8 +20,8 @@ test('test injection', t => {
   t.equal(instance.getCount(), 0, 'starts with 0 declarations');
   const decl1 = {prop: 'color', val: 'red'};
   instance.injectDeclaration(decl1);
-  t.equal(instance.getCache().color.red, 'a');
-  t.equal(instance.getCachedDeclaration(decl1), 'a');
+  t.equal(instance.getCache()['color:red'], 'a');
+  t.equal(instance.getCachedDeclaration({block: 'color:red'}), 'a');
   t.equal(instance.getCount(), 1, 'unique count incremented');
   instance.injectDeclaration(decl1);
   t.equal(
@@ -30,13 +30,13 @@ test('test injection', t => {
     'unique count not incremented after repeat injection'
   );
   instance.injectDeclaration({prop: 'color', val: 'green'});
-  t.equal(instance.getCache().color.green, 'b');
+  t.equal(instance.getCache()['color:green'], 'b');
   instance.injectDeclaration({
     prop: 'color',
     val: 'green',
     media: '(max-width: 800px)',
   });
-  t.equal(instance.getCache().media['(max-width: 800px)'].color.green, 'c');
+  t.equal(instance.getCache().media['(max-width: 800px)']['color:green'], 'c');
   instance.injectDeclaration({
     prop: 'color',
     val: 'green',
@@ -44,8 +44,9 @@ test('test injection', t => {
     pseudo: ':hover',
   });
   t.equal(
-    instance.getCache().media['(max-width: 800px)'].pseudo[':hover'].color
-      .green,
+    instance.getCache().media['(max-width: 800px)'].pseudo[':hover'][
+      'color:green'
+    ],
     'd'
   );
   instance.injectDeclaration({
@@ -53,7 +54,48 @@ test('test injection', t => {
     val: 'none',
     pseudo: ':hover',
   });
-  t.equal(instance.getCache().pseudo[':hover'].display.none, 'e');
+  t.equal(instance.getCache().pseudo[':hover']['display:none'], 'e');
+  t.equal(instance.getCount(), 5, 'ends with 4 unique declarations');
+  t.end();
+});
+
+test('test raw injection', t => {
+  const instance = new StyletronTest();
+  t.equal(instance.getCount(), 0, 'starts with 0 declarations');
+  const block1 = 'color:red';
+  const decl1 = {block: block1};
+  instance.injectRawDeclaration(decl1);
+  t.equal(instance.getCache()[block1], 'a');
+  t.equal(instance.getCachedDeclaration(decl1), 'a');
+  t.equal(instance.getCount(), 1, 'unique count incremented');
+  instance.injectRawDeclaration(decl1);
+  t.equal(
+    instance.getCount(),
+    1,
+    'unique count not incremented after repeat injection'
+  );
+  const block2 = 'color:green';
+  instance.injectRawDeclaration({block: block2});
+  t.equal(instance.getCache()[block2], 'b');
+  instance.injectRawDeclaration({
+    block: block2,
+    media: '(max-width: 800px)',
+  });
+  t.equal(instance.getCache().media['(max-width: 800px)'][block2], 'c');
+  instance.injectRawDeclaration({
+    block: block2,
+    media: '(max-width: 800px)',
+    pseudo: ':hover',
+  });
+  t.equal(
+    instance.getCache().media['(max-width: 800px)'].pseudo[':hover'][block2],
+    'd'
+  );
+  instance.injectRawDeclaration({
+    block: block2,
+    pseudo: ':hover',
+  });
+  t.equal(instance.getCache().pseudo[':hover'][block2], 'e');
   t.equal(instance.getCount(), 5, 'ends with 4 unique declarations');
   t.end();
 });
@@ -68,9 +110,10 @@ test('test injection with prefix', t => {
   const instance = new StyletronTest({prefix: 'qq'});
   t.equal(instance.prefix, 'qq', 'prefix is set on instance');
   t.equal(instance.getCount(), 0, 'starts with 0 declarations');
-  const decl1 = {prop: 'color', val: 'red'};
-  instance.injectDeclaration(decl1);
-  t.equal(instance.getCache().color.red, 'qqa');
+  const block1 = 'color:red';
+  const decl1 = {block: block1};
+  instance.injectRawDeclaration(decl1);
+  t.equal(instance.getCache()[block1], 'qqa');
   t.equal(instance.getCachedDeclaration(decl1), 'qqa');
   t.equal(instance.getCount(), 1, 'unique count incremented');
   t.end();

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -21,7 +21,7 @@ class StyletronCore {
   }
 
   static assignDecl(target, decl, className) {
-    const {prop, val, media, pseudo} = decl;
+    const {block, media, pseudo} = decl;
     let targetEntry;
     if (media) {
       if (!target.media[media]) {
@@ -37,10 +37,7 @@ class StyletronCore {
       }
       targetEntry = targetEntry.pseudo[pseudo];
     }
-    if (!targetEntry[prop]) {
-      targetEntry[prop] = {};
-    }
-    targetEntry[prop][val] = className;
+    targetEntry[block] = className;
   }
 
   /**
@@ -52,7 +49,19 @@ class StyletronCore {
    * @param  {string} [decl.pseudo] The pseudo selector
    * @return {string|undefined}     The class name for the declaration
    */
-  injectDeclaration(decl) {
+  injectDeclaration({prop, val, media, pseudo}) {
+    return this.injectRawDeclaration({block: `${prop}:${val}`, media, pseudo});
+  }
+
+  /**
+   * Injects a raw declaration (if not already injected) and returns a class name
+   * @param  {object} decl          The CSS declaration object
+   * @param  {string} decl.block    The declaration block
+   * @param  {string} [decl.media]  The media query
+   * @param  {string} [decl.pseudo] The pseudo selector
+   * @return {string|undefined}     The class name for the declaration
+   */
+  injectRawDeclaration(decl) {
     const cached = this.getCachedDeclaration(decl);
     if (cached) {
       return cached;
@@ -83,14 +92,13 @@ class StyletronCore {
   /**
    * Gets the class name for an already injected declaration
    * @param  {object} decl          The CSS declaration object
-   * @param  {string} decl.prop     The property name
-   * @param  {string} decl.val      The property value
+   * @param  {string} decl.block    The declaration block
    * @param  {string} [decl.media]  The media query
    * @param  {string} [decl.pseudo] The pseudo selector
    * @return {string|undefined}     The class name for the declaration
    * @private
    */
-  getCachedDeclaration({prop, val, media, pseudo}) {
+  getCachedDeclaration({block, media, pseudo}) {
     let entry;
     if (media) {
       entry = this.cache.media[media];
@@ -106,7 +114,7 @@ class StyletronCore {
         return false;
       }
     }
-    return entry[prop] && entry[prop].hasOwnProperty(val) && entry[prop][val];
+    return entry[block];
   }
 }
 

--- a/packages/styletron-server/src/__tests__/index.js
+++ b/packages/styletron-server/src/__tests__/index.js
@@ -55,7 +55,7 @@ test('test getStylesheetsOldIE method', t => {
     instance.injectRawDeclaration({block: `font-size:${i}px`});
   }
   t.equal(instance.getStylesheetsOldIE().length, 1, 'only one sheet');
-  instance.injectRawDeclaration({block: 'color:red'});
+  instance.injectRawDeclaration({block: 'color:red', pseudo: ':hover'});
   t.equal(
     instance.getStylesheetsOldIE().length,
     2,
@@ -71,6 +71,7 @@ test('test getStylesheetsOldIE method', t => {
   instance.injectRawDeclaration({
     block: 'color:red',
     media: '(max-width: 400px)',
+    pseudo: ':hover',
   });
   t.equal(instance.getStylesheetsOldIE().length, 4, 'media sheet rollover');
   t.end();

--- a/packages/styletron-server/src/__tests__/index.js
+++ b/packages/styletron-server/src/__tests__/index.js
@@ -52,26 +52,24 @@ test('test getStylesheetsHtml method', t => {
 test('test getStylesheetsOldIE method', t => {
   const instance = new StyletronTest();
   for (let i = 0; i <= 4095; i++) {
-    instance.injectDeclaration({prop: 'font-size', val: `${i}px`});
+    instance.injectRawDeclaration({block: `font-size:${i}px`});
   }
   t.equal(instance.getStylesheetsOldIE().length, 1, 'only one sheet');
-  instance.injectDeclaration({prop: 'color', val: 'red'});
+  instance.injectRawDeclaration({block: 'color:red'});
   t.equal(
     instance.getStylesheetsOldIE().length,
     2,
     'rollover into another sheet'
   );
   for (let i = 0; i <= 4095; i++) {
-    instance.injectDeclaration({
-      prop: 'font-size',
-      val: `${i}px`,
+    instance.injectRawDeclaration({
+      block: `font-size:${i}px`,
       media: '(max-width: 400px)',
     });
   }
   t.equal(instance.getStylesheetsOldIE().length, 3, 'media sheet');
-  instance.injectDeclaration({
-    prop: 'color',
-    val: 'red',
+  instance.injectRawDeclaration({
+    block: 'color:red',
     media: '(max-width: 400px)',
   });
   t.equal(instance.getStylesheetsOldIE().length, 4, 'media sheet rollover');

--- a/packages/styletron-server/src/base-obj-to-css.js
+++ b/packages/styletron-server/src/base-obj-to-css.js
@@ -1,32 +1,23 @@
 export default baseHandler;
 
-function baseHandler(key, valueObj) {
+function baseHandler(key, objOrClassName) {
   return key === 'pseudo'
-    ? pseudoObjToCss(valueObj)
-    : valsObjToCss(key, valueObj);
+    ? pseudoObjToCss(objOrClassName)
+    : declToCss(key, objOrClassName);
 }
 
 function pseudoObjToCss(pseudoObj) {
   let css = '';
   for (const pseudoClass in pseudoObj) {
     const propsObj = pseudoObj[pseudoClass];
-    for (const prop in propsObj) {
-      css += valsObjToCss(prop, propsObj[prop], pseudoClass);
+    for (const block in propsObj) {
+      css += declToCss(block, propsObj[block], pseudoClass);
     }
   }
   return css;
 }
 
-function valsObjToCss(prop, valsObj, pseudo) {
-  let css = '';
-  for (const val in valsObj) {
-    const className = valsObj[val];
-    css += declToCss(prop, val, className, pseudo);
-  }
-  return css;
-}
-
-function declToCss(prop, val, className, pseudo) {
-  const classString = pseudo ? `${className}${pseudo}` : className;
-  return `.${classString}{${prop}:${val}}`;
+function declToCss(block, className, pseudo) {
+  const selector = pseudo ? `${className}${pseudo}` : className;
+  return `.${selector}{${block}}`;
 }

--- a/packages/styletron-server/src/cache-to-stylesheets-old-ie.js
+++ b/packages/styletron-server/src/cache-to-stylesheets-old-ie.js
@@ -20,7 +20,9 @@ function cacheToStylesheetsOldIE(cacheObj) {
       mediaSheets = getMediaSheets(cacheObj[key]);
       continue;
     }
-    if (typeof cacheObj[key] === 'string') {
+    if (typeof cacheObj[key] === 'object') {
+      ruleCount += Object.keys(cacheObj[key]).length;
+    } else {
       ruleCount++;
     }
     mainCss += baseHandler(key, cacheObj[key]);
@@ -44,7 +46,9 @@ function getMediaSheets(mediaObj) {
     let mediaCss = '';
     let ruleCount = 0;
     for (const key in obj) {
-      if (typeof obj[key] === 'string') {
+      if (typeof obj[key] === 'object') {
+        ruleCount += Object.keys(obj[key]).length;
+      } else {
         ruleCount++;
       }
       mediaCss += baseHandler(key, obj[key]);

--- a/packages/styletron-server/src/cache-to-stylesheets-old-ie.js
+++ b/packages/styletron-server/src/cache-to-stylesheets-old-ie.js
@@ -20,7 +20,9 @@ function cacheToStylesheetsOldIE(cacheObj) {
       mediaSheets = getMediaSheets(cacheObj[key]);
       continue;
     }
-    ruleCount += Object.keys(cacheObj[key]).length;
+    if (typeof cacheObj[key] === 'string') {
+      ruleCount++;
+    }
     mainCss += baseHandler(key, cacheObj[key]);
     // TODO: handle case of than 4095 unique values for a single property
     if (ruleCount > IE9_RULE_LIMIT && mainCss) {
@@ -42,14 +44,16 @@ function getMediaSheets(mediaObj) {
     let mediaCss = '';
     let ruleCount = 0;
     for (const key in obj) {
-      ruleCount += Object.keys(obj[key]).length;
+      if (typeof obj[key] === 'string') {
+        ruleCount++;
+      }
+      mediaCss += baseHandler(key, obj[key]);
       // TODO: handle case of than 4095 unique values for a single property
       if (ruleCount > IE9_RULE_LIMIT && mediaCss) {
         stylesheets.push({media: query, css: mediaCss});
         mediaCss = '';
         ruleCount = 0;
       }
-      mediaCss += baseHandler(key, obj[key]);
     }
     if (mediaCss) {
       stylesheets.push({

--- a/packages/styletron-server/src/index.js
+++ b/packages/styletron-server/src/index.js
@@ -17,14 +17,6 @@ class StyletronServer extends StyletronCore {
     super(opts);
   }
 
-  injectDeclaration(decl) {
-    return super.injectDeclaration(decl);
-  }
-
-  injectRawDeclaration(decl) {
-    return super.injectRawDeclaration(decl);
-  }
-
   /**
    * Get an array of stylesheet objects
    * @return {Array} Array of stylesheet objects

--- a/packages/styletron-server/src/index.js
+++ b/packages/styletron-server/src/index.js
@@ -21,6 +21,10 @@ class StyletronServer extends StyletronCore {
     return super.injectDeclaration(decl);
   }
 
+  injectRawDeclaration(decl) {
+    return super.injectRawDeclaration(decl);
+  }
+
   /**
    * Get an array of stylesheet objects
    * @return {Array} Array of stylesheet objects
@@ -87,7 +91,7 @@ class StyletronServer extends StyletronCore {
 
   /**
    * Get the CSS string. For hydrating styles on the client,
-   * [`getStylesheetsHtml`]{@link StyletronServer#getStylesheetsHtml} or [`getStylesheets`]{@link StyletronServer#getStylesheets} should be used instead. 
+   * [`getStylesheetsHtml`]{@link StyletronServer#getStylesheetsHtml} or [`getStylesheets`]{@link StyletronServer#getStylesheets} should be used instead.
    * @return {String} The string of CSS
    * @example
    * const styletron = new StyletronServer();

--- a/packages/styletron-utils/src/__tests__/index.js
+++ b/packages/styletron-utils/src/__tests__/index.js
@@ -5,7 +5,7 @@ import test from 'tape';
 test('test injection', t => {
   const decls = [];
   const spy = {
-    injectDeclaration: decl => {
+    injectRawDeclaration: decl => {
       decls.push(decl);
       return decls.length;
     },
@@ -22,20 +22,18 @@ test('test injection', t => {
   });
   t.equal(classString, '1 2 3 4');
   t.deepEqual(decls, [
-    {prop: 'color', val: 'red', media: undefined, pseudo: undefined},
+    {block: 'color:red', media: undefined, pseudo: undefined},
     {
-      prop: 'background-color',
-      val: 'blue',
+      block: 'background-color:blue',
       media: undefined,
       pseudo: undefined,
     },
     {
-      prop: 'color',
-      val: 'purple',
+      block: 'color:purple',
       media: '(max-width: 500px)',
       pseudo: undefined,
     },
-    {prop: 'background', val: 'orange', media: undefined, pseudo: ':hover'},
+    {block: 'background:orange', media: undefined, pseudo: ':hover'},
   ]);
   t.end();
 });
@@ -43,7 +41,7 @@ test('test injection', t => {
 test('test injection array', function(t) {
   const decls = [];
   const spy = {
-    injectDeclaration: function(decl) {
+    injectRawDeclaration: function(decl) {
       decls.push(decl);
       return decls.length;
     },
@@ -57,24 +55,15 @@ test('test injection array', function(t) {
       color: ['green', 'yellow'],
     },
   });
-  t.equal(classString, '1 2 3 4 5 6');
+  t.equal(classString, '1 2 3');
   t.deepEqual(decls, [
-    {prop: 'color', val: 'red', media: undefined, pseudo: undefined},
-    {prop: 'color', val: 'blue', media: undefined, pseudo: undefined},
+    {block: 'color:red;color:blue', media: undefined, pseudo: undefined},
     {
-      prop: 'color',
-      val: 'purple',
+      block: 'color:purple;color:orange',
       media: '(max-width: 500px)',
       pseudo: undefined,
     },
-    {
-      prop: 'color',
-      val: 'orange',
-      media: '(max-width: 500px)',
-      pseudo: undefined,
-    },
-    {prop: 'color', val: 'green', media: undefined, pseudo: ':hover'},
-    {prop: 'color', val: 'yellow', media: undefined, pseudo: ':hover'},
+    {block: 'color:green;color:yellow', media: undefined, pseudo: ':hover'},
   ]);
   t.end();
 });
@@ -82,7 +71,7 @@ test('test injection array', function(t) {
 test('test injection prefixed', function(t) {
   const decls = [];
   const spy = {
-    injectDeclaration: function(decl) {
+    injectRawDeclaration: function(decl) {
       decls.push(decl);
       return decls.length;
     },
@@ -92,41 +81,20 @@ test('test injection prefixed', function(t) {
     height: ['min-content', 'calc(50%)'],
     boxSizing: 'border-box',
   });
-  t.equal(classString, '1 2 3 4 5 6');
+  t.equal(classString, '1 2 3');
   t.deepEqual(decls, [
     {
-      prop: 'width',
-      val: 'calc(100%)',
+      block: 'width:calc(100%)',
       media: undefined,
       pseudo: undefined,
     },
     {
-      prop: 'height',
-      val: '-webkit-min-content',
+      block: 'height:-webkit-min-content;height:-moz-min-content;height:min-content;height:calc(50%)',
       media: undefined,
       pseudo: undefined,
     },
     {
-      prop: 'height',
-      val: '-moz-min-content',
-      media: undefined,
-      pseudo: undefined,
-    },
-    {
-      prop: 'height',
-      val: 'min-content',
-      media: undefined,
-      pseudo: undefined,
-    },
-    {
-      prop: 'height',
-      val: 'calc(50%)',
-      media: undefined,
-      pseudo: undefined,
-    },
-    {
-      prop: 'box-sizing',
-      val: 'border-box',
+      block: 'box-sizing:border-box',
       media: undefined,
       pseudo: undefined,
     },

--- a/packages/styletron-utils/src/__tests__/index.js
+++ b/packages/styletron-utils/src/__tests__/index.js
@@ -77,25 +77,41 @@ test('test injection prefixed', function(t) {
     },
   };
   const classString = injectStylePrefixed(spy, {
-    width: 'calc(100%)',
-    height: ['min-content', 'calc(50%)'],
-    boxSizing: 'border-box',
+    display: 'flex',
+    height: ['min-content', '100%'],
+    transition: 'height 1s',
+    ':hover': {
+      backgroundColor: 'linear-gradient(to bottom, red, green)',
+    },
+    '@media (max-width: 500px)': {
+      flexGrow: 1,
+    },
   });
-  t.equal(classString, '1 2 3');
+  t.equal(classString, '1 2 3 4 5');
   t.deepEqual(decls, [
     {
-      block: 'width:calc(100%)',
+      block: 'display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex',
       media: undefined,
       pseudo: undefined,
     },
     {
-      block: 'height:-webkit-min-content;height:-moz-min-content;height:min-content;height:calc(50%)',
+      block: 'height:-webkit-min-content;height:-moz-min-content;height:min-content;height:100%',
       media: undefined,
       pseudo: undefined,
     },
     {
-      block: 'box-sizing:border-box',
+      block: 'transition:height 1s;-webkit-transition:height 1s;-moz-transition:height 1s',
       media: undefined,
+      pseudo: undefined,
+    },
+    {
+      block: 'background-color:-webkit-linear-gradient(to bottom, red, green);background-color:-moz-linear-gradient(to bottom, red, green);background-color:linear-gradient(to bottom, red, green)',
+      media: undefined,
+      pseudo: ':hover',
+    },
+    {
+      block: 'flex-grow:1;-webkit-flex-grow:1',
+      media: '(max-width: 500px)',
       pseudo: undefined,
     },
   ]);

--- a/packages/styletron-utils/src/__tests__/index.js
+++ b/packages/styletron-utils/src/__tests__/index.js
@@ -117,3 +117,39 @@ test('test injection prefixed', function(t) {
   ]);
   t.end();
 });
+
+test('test prefixed cache', function(t) {
+  const decls = [];
+  const spy = {
+    injectRawDeclaration: function(decl) {
+      decls.push(decl);
+      return decls.length;
+    },
+  };
+  const cache = {flexGrow: {1: 'color:red'}};
+  injectStylePrefixed(
+    spy,
+    {
+      display: 'flex',
+      flexGrow: 1,
+    },
+    undefined,
+    undefined,
+    cache
+  );
+  t.deepEqual(cache, {
+    display: {
+      flex: 'display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex',
+    },
+    flexGrow: {1: 'color:red'},
+  });
+  t.deepEqual(decls, [
+    {
+      block: 'display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex',
+      media: undefined,
+      pseudo: undefined,
+    },
+    {block: 'color:red', media: undefined, pseudo: undefined},
+  ]);
+  t.end();
+});

--- a/packages/styletron-utils/src/inject-style-prefixed.js
+++ b/packages/styletron-utils/src/inject-style-prefixed.js
@@ -1,6 +1,60 @@
-import injectStyle from './inject-style';
+import hyphenate from './hyphenate-style-name';
 import prefixAll from 'inline-style-prefixer/static';
 
 export default function injectStylePrefixed(styletron, styles, media, pseudo) {
-  return injectStyle(styletron, prefixAll(styles), media, pseudo);
+  let classString = '';
+  for (const originalKey in styles) {
+    const originalVal = styles[originalKey];
+    const originalValType = typeof originalVal;
+    if (
+      originalValType === 'string' ||
+      originalValType === 'number' ||
+      Array.isArray(originalVal)
+    ) {
+      const prefixed = prefixAll({[originalKey]: originalVal});
+      let block = '';
+      for (const prefixedKey in prefixed) {
+        const prefixedVal = prefixed[prefixedKey];
+        const prefixedValType = typeof prefixedVal;
+        if (prefixedValType === 'string' || prefixedValType === 'number') {
+          block += `${hyphenate(prefixedKey)}:${prefixedVal};`;
+          continue;
+        }
+        if (Array.isArray(prefixedVal)) {
+          const hyphenated = hyphenate(prefixedKey);
+          for (let i = 0; i < prefixedVal.length; i++) {
+            block += `${hyphenated}:${prefixedVal[i]};`;
+          }
+          continue;
+        }
+      }
+      classString +=
+        ' ' +
+        styletron.injectRawDeclaration({
+          block: block.slice(0, -1), // Remove trailing semicolon
+          media,
+          pseudo,
+        });
+    }
+    if (originalValType === 'object') {
+      if (originalKey[0] === ':') {
+        classString +=
+          ' ' + injectStylePrefixed(styletron, originalVal, media, originalKey);
+        continue;
+      }
+      if (originalKey.substring(0, 6) === '@media') {
+        classString +=
+          ' ' +
+          injectStylePrefixed(
+            styletron,
+            originalVal,
+            originalKey.substr(7),
+            pseudo
+          );
+        continue;
+      }
+    }
+  }
+  // remove leading space on way out
+  return classString.slice(1);
 }

--- a/packages/styletron-utils/src/inject-style-prefixed.js
+++ b/packages/styletron-utils/src/inject-style-prefixed.js
@@ -3,7 +3,13 @@ import prefixAll from 'inline-style-prefixer/static';
 
 const prefixedBlockCache = {};
 
-export default function injectStylePrefixed(styletron, styles, media, pseudo) {
+export default function injectStylePrefixed(
+  styletron,
+  styles,
+  media,
+  pseudo,
+  cache = prefixedBlockCache
+) {
   let classString = '';
   for (const originalKey in styles) {
     const originalVal = styles[originalKey];
@@ -14,10 +20,10 @@ export default function injectStylePrefixed(styletron, styles, media, pseudo) {
       let block = '';
       if (
         isPrimitiveVal &&
-        prefixedBlockCache.hasOwnProperty(originalKey) &&
-        prefixedBlockCache[originalKey].hasOwnProperty(originalVal)
+        cache.hasOwnProperty(originalKey) &&
+        cache[originalKey].hasOwnProperty(originalVal)
       ) {
-        block = prefixedBlockCache[originalKey][originalVal];
+        block = cache[originalKey][originalVal];
       } else {
         const prefixed = prefixAll({[originalKey]: originalVal});
         for (const prefixedKey in prefixed) {
@@ -37,10 +43,10 @@ export default function injectStylePrefixed(styletron, styles, media, pseudo) {
         }
         block = block.slice(0, -1); // Remove trailing semicolon
         if (isPrimitiveVal) {
-          if (!prefixedBlockCache.hasOwnProperty(originalKey)) {
-            prefixedBlockCache[originalKey] = {};
+          if (!cache.hasOwnProperty(originalKey)) {
+            cache[originalKey] = {};
           }
-          prefixedBlockCache[originalKey][originalVal] = block;
+          cache[originalKey][originalVal] = block;
         }
       }
       classString +=
@@ -54,7 +60,14 @@ export default function injectStylePrefixed(styletron, styles, media, pseudo) {
     if (originalValType === 'object') {
       if (originalKey[0] === ':') {
         classString +=
-          ' ' + injectStylePrefixed(styletron, originalVal, media, originalKey);
+          ' ' +
+          injectStylePrefixed(
+            styletron,
+            originalVal,
+            media,
+            originalKey,
+            cache
+          );
         continue;
       }
       if (originalKey.substring(0, 6) === '@media') {
@@ -64,7 +77,8 @@ export default function injectStylePrefixed(styletron, styles, media, pseudo) {
             styletron,
             originalVal,
             originalKey.substr(7),
-            pseudo
+            pseudo,
+            cache
           );
         continue;
       }

--- a/packages/styletron-utils/src/inject-style.js
+++ b/packages/styletron-utils/src/inject-style.js
@@ -8,26 +8,29 @@ export default function injectStyle(styletron, styles, media, pseudo) {
     if (valType === 'string' || valType === 'number') {
       classString +=
         ' ' +
-        styletron.injectDeclaration({
-          prop: hyphenate(key),
-          val,
+        styletron.injectRawDeclaration({
+          block: `${hyphenate(key)}:${val}`,
           media,
           pseudo,
         });
       continue;
     }
     if (Array.isArray(val)) {
-      for (let i = 0; i < val.length; i++) {
-        const hyphenated = hyphenate(key);
-        classString +=
-          ' ' +
-          styletron.injectDeclaration({
-            prop: hyphenated,
-            val: val[i],
-            media,
-            pseudo,
-          });
+      if (val.length === 0) {
+        continue;
       }
+      const hyphenated = hyphenate(key);
+      let block = `${hyphenated}:${val[0]}`;
+      for (let i = 1; i < val.length; i++) {
+        block += `;${hyphenated}:${val[i]}`;
+      }
+      classString +=
+        ' ' +
+        styletron.injectRawDeclaration({
+          block,
+          media,
+          pseudo,
+        });
       continue;
     }
     if (valType === 'object') {

--- a/packages/test-fixtures/basic.js
+++ b/packages/test-fixtures/basic.js
@@ -3,25 +3,17 @@ module.exports = {
     '(max-width: 800px)': {
       pseudo: {
         ':hover': {
-          color: {
-            green: 'd',
-          },
+          'color:green': 'd',
         },
       },
-      color: {
-        green: 'c',
-      },
+      'color:green': 'c',
     },
   },
   pseudo: {
     ':hover': {
-      display: {
-        none: 'e',
-      },
+      'display:none': 'e',
     },
   },
-  color: {
-    red: 'a',
-    green: 'b',
-  },
+  'color:red': 'a',
+  'color:green': 'b',
 };


### PR DESCRIPTION
This PR is on top of #133 and fixes #104.

In this implementation of `injectStylePrefixed` each entity is run through `prefixAll` by `inline-style-prefixer` and injects as a single atomic class using the `injectRawDeclaration`.

This will significantly reduce the number of class names which will theoretically have better performance, ease debugging and result in fewer bytes using SSR, see #104.

The computed block for each unique prefixed entity (property + value) is cached so it will only go through the prefixer once and should make e.g. renders in React faster. It only cache when the style value is a string or number since it's easier to cache primitives. I'm not sure whether complexity of caching arrays (fallback values) will be worth it since they are not that widely used.