### PR TITLE
Enable a `selectorPrefix` on styletron-client

### DIFF
--- a/packages/styletron-client/src/styletron-client.js
+++ b/packages/styletron-client/src/styletron-client.js
@@ -18,6 +18,7 @@ class StyletronClient extends StyletronCore {
    */
   constructor(serverStyles, opts) {
     super(opts);
+    this.selectorPrefix = opts ? opts.selectorPrefix : undefined;
     this.uniqueCount = 0;
     this.mediaSheets = {};
     if (serverStyles) {
@@ -78,7 +79,7 @@ class StyletronClient extends StyletronCore {
     const oldCount = this.uniqueCount;
     const className = super.injectDeclaration(decl);
     if (oldCount !== this.uniqueCount) {
-      const rule = declarationToRule(className, decl);
+      const rule = declarationToRule(className, decl, this.selectorPrefix);
       let sheet;
       if (decl.media) {
         if (!this.mediaSheets[decl.media]) {
@@ -103,9 +104,9 @@ module.exports = StyletronClient;
  * Injection helpers
  */
 
-function declarationToRule(className, {prop, val, pseudo}) {
+function declarationToRule(className, {prop, val, pseudo}, selectorPrefix) {
   const decl = `${prop}:${val}`;
-  let selector = `.${className}`;
+  let selector = `${selectorPrefix ? `${selectorPrefix} ` : ''}.${className}`;
   if (pseudo) {
     selector += pseudo;
   }


### PR DESCRIPTION
Allows a "selectorPrefix" to be injected into the page for applications where a react app may be nested on a third party page.

Ensures that "resets" and other things can be applied and not "override" the attribute on the element.

Precludes the need to define every "reset" or "host page" override for every element in your code.

Utilized:
```
const styletron = new Styletron(styleElements, { selectorPrefix: '.SOME_WIDGET' });
```

Will continue to produce class names on the elements with their standard minification.  Class names injected into the `<style />` tags will have a prefix on them.    ie:

```
<style type="text/css">
.SOME_WIDGET b { color: 'red' }
</style>
```