### PR TITLE
Add display name in development mode

### DIFF
--- a/packages/styletron-react/src/__tests__/browser.js
+++ b/packages/styletron-react/src/__tests__/browser.js
@@ -1,3 +1,4 @@
+/* global process */
 /* eslint-env browser */
 
 import test from 'tape';
@@ -241,5 +242,97 @@ test('styled merges class name prop', t => {
   );
   const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
   t.equal(div.className, 'foo a', 'matches expected classes');
+  t.end();
+});
+
+test('core sets display name', t => {
+  const env = process.env.NODE_ENV;
+
+  function developmentDisplayName(createComponent) {
+    process.env.NODE_ENV = 'development';
+    const displayName = createComponent().displayName;
+    process.env.NODE_ENV = env;
+    return displayName;
+  }
+  function productionDisplayName(createComponent) {
+    process.env.NODE_ENV = 'production';
+    const displayName = createComponent().displayName;
+    process.env.NODE_ENV = env;
+    return displayName;
+  }
+
+  t.equal(
+    developmentDisplayName(() => styled('div', {color: 'red'})),
+    'Styled(div)',
+    'matches expected display name'
+  );
+  t.equal(
+    productionDisplayName(() => styled('div', {color: 'red'})),
+    void 0,
+    'matches expected display name'
+  );
+
+  class TestComponentClass extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  t.equal(
+    developmentDisplayName(() => styled(TestComponentClass, {color: 'red'})),
+    'Styled(TestComponentClass)',
+    'matches expected display name'
+  );
+  t.equal(
+    productionDisplayName(() => styled(TestComponentClass, {color: 'red'})),
+    void 0,
+    'matches expected display name'
+  );
+
+  TestComponentClass.displayName = 'Test';
+
+  t.equal(
+    developmentDisplayName(() => styled(TestComponentClass, {color: 'red'})),
+    'Styled(Test)',
+    'matches expected display name'
+  );
+  t.equal(
+    productionDisplayName(() => styled(TestComponentClass, {color: 'red'})),
+    void 0,
+    'matches expected display name'
+  );
+
+  function TestStatelessComponent() {
+    return <div />;
+  }
+
+  t.equal(
+    developmentDisplayName(() =>
+      styled(TestStatelessComponent, {color: 'red'})
+    ),
+    'Styled(TestStatelessComponent)',
+    'matches expected display name'
+  );
+  t.equal(
+    productionDisplayName(() => styled(TestStatelessComponent, {color: 'red'})),
+    void 0,
+    'matches expected display name'
+  );
+
+  TestStatelessComponent.displayName = 'Test';
+
+  t.equal(
+    developmentDisplayName(() =>
+      styled(TestStatelessComponent, {color: 'red'})
+    ),
+    'Styled(Test)',
+    'matches expected display name'
+  );
+  t.equal(
+    productionDisplayName(() => styled(TestStatelessComponent, {color: 'red'})),
+    void 0,
+    'matches expected display name'
+  );
+
   t.end();
 });

--- a/packages/styletron-react/src/core.js
+++ b/packages/styletron-react/src/core.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -25,7 +27,7 @@ export default function core(base, style, assignProps) {
   throw new Error('`styled` takes either a DOM element name or a component');
 }
 
-function createStyledElementComponent(tagName, stylesArray, assignProps) {
+function createStyledElementComponent(base, stylesArray, assignProps) {
   function StyledElement(props, context) {
     const ownProps = assign({}, props);
     delete ownProps.innerRef;
@@ -58,11 +60,18 @@ function createStyledElementComponent(tagName, stylesArray, assignProps) {
   }
 
   StyledElement[STYLETRON_KEY] = {
-    tag: tagName,
+    tag: base,
     styles: stylesArray,
   };
 
   StyledElement.contextTypes = {styletron: PropTypes.object};
+
+  if (process.env.NODE_ENV !== 'production') {
+    const name = base.displayName
+      ? base.displayName
+      : typeof base === 'function' ? base.name : base;
+    StyledElement.displayName = `Styled${name ? `(${name})` : ''}`;
+  }
 
   return StyledElement;
 }

--- a/packages/styletron-react/src/core.js
+++ b/packages/styletron-react/src/core.js
@@ -1,5 +1,3 @@
-/* global process */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -66,7 +64,7 @@ function createStyledElementComponent(base, stylesArray, assignProps) {
 
   StyledElement.contextTypes = {styletron: PropTypes.object};
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (__DEV__) {
     const name = base.displayName
       ? base.displayName
       : typeof base === 'function' ? base.name : base;


### PR DESCRIPTION
Inherits it's element `displayName` like `Styled(DummyComponent)` or string `Styled(div)`. Fallbacks to function name if `displayName` is undefined. Makes it easier to debug using e.g. React DevTools.