### PR TITLE
Add styled props prop

### DIFF
--- a/packages/styletron-react/src/__tests__/browser.js
+++ b/packages/styletron-react/src/__tests__/browser.js
@@ -230,6 +230,40 @@ test('innerRef not passed', t => {
   );
 });
 
+test('styleProps not passed', t => {
+  t.plan(1);
+
+  class InnerComponent extends React.Component {
+    render() {
+      t.deepEqual(
+        this.props,
+        {
+          className: 'a',
+          'data-foo': 'bar',
+        },
+        'props match expected'
+      );
+      return <button>InnerComponent</button>;
+    }
+  }
+
+  const Widget = styled(InnerComponent, {color: 'red'});
+  const styletron = new Styletron();
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(
+      Provider,
+      {styletron},
+      React.createElement(Widget, {
+        'data-foo': 'bar',
+        styleProps: {
+          baz: 'qux',
+        },
+      })
+    )
+  );
+});
+
 test('styled merges class name prop', t => {
   const Widget = styled('div', {color: 'red'});
   const styletron = new Styletron();

--- a/packages/styletron-react/src/core.js
+++ b/packages/styletron-react/src/core.js
@@ -45,15 +45,6 @@ function createStyledElementComponent(base, stylesArray, assignProps) {
       elementProps.ref = props.innerRef;
     }
 
-    if (typeof StyledElement[STYLETRON_KEY].tag === 'string') {
-      // Use custom element workaround to avoid warnings for "invalid" attributes
-      elementProps.is = true;
-      // Because of this, we need to use true `class` and `for` attributes
-      elementProps.class = elementProps.className;
-      elementProps.className = void 0;
-      elementProps.for = elementProps.htmlFor;
-    }
-
     return React.createElement(StyledElement[STYLETRON_KEY].tag, elementProps);
   }
 

--- a/packages/styletron-react/src/styled.js
+++ b/packages/styletron-react/src/styled.js
@@ -43,6 +43,9 @@ export default function styled(base, style) {
 function assignProps(styletron, styleResult, ownProps) {
   const styletronClassName = injectStylePrefixed(styletron, styleResult);
   // Skipping cloning of `ownProps` since that's already done internally
+  if (ownProps.styleProps) {
+    delete ownProps.styleProps;
+  }
   ownProps.className = ownProps.className
     ? `${ownProps.className} ${styletronClassName}`
     : styletronClassName;


### PR DESCRIPTION
This approach to solve #167 is the easiest and the most straight forward one. It provides a specific prop which will be deleted before they pass to the inner component.

It makes it compatible with the current implementation (*but will pass props to the DOM if you use React 16*) and is faily easy to migrate to.

if  you have something like this...
```tsx
const Button = styled('button', styleProps => ({
   ...,
   background: styleProps.dark ? 'black' : 'white',
}));

<Button theme="dark" size="large" type="button" onClick={() => ...}>Click me</Button>
```
You will have to do this instead to prevent `theme` and `size` to render to the DOM...
```tsx
const Button = styled('button', ({styleProps}) => ({
   ...,
   background: styleProps.dark ? 'black' : 'white',
}));

<Button styleProps={{theme='dark', size: 'large'}} type="button" onClick={() => ...}>Click me</Button>
```

It's not as pretty. But React 16 is released really soon and this issue really can't block projects from upgrading.