### PR TITLE
Create stylesheet if we don't have at least one

### DIFF
--- a/packages/styletron-client/src/__tests__/browser.js
+++ b/packages/styletron-client/src/__tests__/browser.js
@@ -85,6 +85,12 @@ test('rule insertion order', t => {
   t.end();
 });
 
+test('with zero length stylesheets', t => {
+  const instance = new StyletronTest([]);
+  t.equal(instance.mainSheet instanceof HTMLStyleElement, true);
+  t.end();
+});
+
 function createFixtures(sheets) {
   return sheets.map(sheet => createStyleElement(sheet.css, sheet.media));
 }

--- a/packages/styletron-client/src/index.js
+++ b/packages/styletron-client/src/index.js
@@ -22,7 +22,7 @@ class StyletronClient extends StyletronCore {
     super(opts);
     this.uniqueCount = 0;
     this.mediaSheets = {};
-    if (serverStyles) {
+    if (serverStyles && serverStyles.length > 0) {
       for (let i = 0; i < serverStyles.length; i++) {
         const element = serverStyles[i];
         if (element.media) {


### PR DESCRIPTION
Because a HTML element collection can be truthy while having a length of 0, we need to also check the length.