### PR TITLE
Fix incorrect default import in styletron-preact

### DIFF
--- a/packages/styletron-preact/src/styled.js
+++ b/packages/styletron-preact/src/styled.js
@@ -67,7 +67,7 @@ function createStyledElementComponent(tagName, stylesArray) {
       }
     });
 
-    const styletronClassName = utils.injectStylePrefixed(
+    const styletronClassName = injectStylePrefixed(
       context.styletron,
       resolvedStyle
     );

--- a/packages/styletron-preact/src/styled.js
+++ b/packages/styletron-preact/src/styled.js
@@ -1,5 +1,5 @@
 import Preact from 'preact';
-import utils from 'styletron-utils';
+import {injectStylePrefixed} from 'styletron-utils';
 
 const STYLETRON_KEY = '__STYLETRON';
 


### PR DESCRIPTION
I'm running into issues with the preact bindings trying to import from a default export that doesn't exist in `styletron-utils`. I'm using webpack.

I noticed that the inferno and react bindings use this import instead, using this resolves the issue.

Let me know if any tests or anything are required.