### PR TITLE
Avoid rendering empty class attribute

### DIFF
--- a/packages/styletron-server/src/generate-html-string.js
+++ b/packages/styletron-server/src/generate-html-string.js
@@ -4,8 +4,9 @@ function generateHtmlString(sheets, className) {
   let html = '';
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
+    const classAttr = className ? ` class="${className}"` : '';
     const mediaAttr = sheet.media ? ` media="${sheet.media}"` : '';
-    html += `<style class="${className}"${mediaAttr}>${sheet.css}</style>`;
+    html += `<style${classAttr}${mediaAttr}>${sheet.css}</style>`;
   }
   return html;
 }


### PR DESCRIPTION
When `className` is blank, `class=""` should not be rendered.