### PR TITLE
Delete vestigial eslint-plugin-cup dependency

### DIFF
--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.37",
     "create-universal-package": "3.2.4",
-    "eslint-plugin-cup": "^1.0.0",
     "react-dom": "16.2.0",
     "react": "16.2.0"
   },

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@types/react": "*",
-    "eslint-plugin-cup": "^1.0.0",
     "prop-types": "^15.6.0",
     "styletron-client": "^3.0.2",
     "styletron-server": "^3.0.2",
@@ -45,8 +44,9 @@
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.37",
     "create-universal-package": "3.2.4",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "eslint-plugin-cup": "^1.0.0",
+    "react-dom": "16.2.0",
+    "react": "16.2.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Installing `styletron-react` ends up bringing in eslint-plugin-cup, which is a devDependency. This also throws a warning when `yarn/npm install`ing dependents of styletron-react: 

```
warning "styletron-react > eslint-plugin-cup@1.0.0" has unmet peer dependency "eslint@4.x".
```