### PR TITLE
Skip "ad" atomic identifiers by default

### DIFF
--- a/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
+++ b/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
@@ -27,7 +27,7 @@ test("automatic stylesheet insertion", t => {
   t.equal(document.styleSheets.length, 0, "sheet not yet instantiated");
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "a",
+    "ae",
     "new unique class returned",
   );
   t.equal(document.styleSheets.length, 1, "sheet added");
@@ -42,29 +42,32 @@ test("rendering", t => {
   const instance = new StyletronClient({container});
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "a",
+    "ae",
     "new unique class returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
-    {media: "", rules: [".a { color: purple; }"]},
+    {media: "", rules: [".ae { color: purple; }"]},
   ]);
   t.equal(
     instance.renderStyle({
       "@media (max-width: 800px)": {color: "purple"},
     }),
-    "b",
+    "af",
     "new unique class returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
-    {media: "", rules: [".a { color: purple; }"]},
-    {media: "(max-width: 800px)", rules: [".b { color: purple; }"]},
+    {media: "", rules: [".ae { color: purple; }"]},
+    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
   instance.renderStyle({
     userSelect: "none",
   });
   t.deepEqual(sheetsToRules(document.styleSheets), [
-    {media: "", rules: [".a { color: purple; }", ".c { user-select: none; }"]},
-    {media: "(max-width: 800px)", rules: [".b { color: purple; }"]},
+    {
+      media: "",
+      rules: [".ae { color: purple; }", ".ag { user-select: none; }"],
+    },
+    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
   instance.renderStyle({
     display: "flex",
@@ -73,12 +76,12 @@ test("rendering", t => {
     {
       media: "",
       rules: [
-        ".a { color: purple; }",
-        ".c { user-select: none; }",
-        ".d { display: flex; }",
+        ".ae { color: purple; }",
+        ".ag { user-select: none; }",
+        ".ah { display: flex; }",
       ],
     },
-    {media: "(max-width: 800px)", rules: [".b { color: purple; }"]},
+    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
   instance.container.remove();
   t.end();
@@ -90,26 +93,26 @@ test("prefix", t => {
   const instance = new StyletronClient({container, prefix: "foo_"});
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "foo_a",
+    "foo_ae",
     "new unique class returned",
   );
   t.equal(
     instance.renderFontFace({src: "url(blah)"}),
-    "foo_a",
+    "foo_ae",
     "new unique font family returned",
   );
   t.equal(
     instance.renderKeyframes({from: {color: "red"}, to: {color: "blue"}}),
-    "foo_a",
+    "foo_ae",
     "new unique animation name returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {
       media: "",
       rules: [
-        ".foo_a { color: purple; }",
-        `@font-face { font-family: foo_a; src: url("blah"); }`,
-        "@keyframes foo_a { \n  0% { color: red; }\n  100% { color: blue; }\n}",
+        ".foo_ae { color: purple; }",
+        `@font-face { font-family: foo_ae; src: url("blah"); }`,
+        "@keyframes foo_ae { \n  0% { color: red; }\n  100% { color: blue; }\n}",
       ],
     },
   ]);

--- a/packages/styletron-engine-atomic/src/sequential-id-generator.js
+++ b/packages/styletron-engine-atomic/src/sequential-id-generator.js
@@ -8,11 +8,12 @@ export default class SequentialIDGenerator {
   power: number;
 
   constructor(prefix: string = "") {
+    // ensure start with "ae" so "ad" is never produced
     this.prefix = prefix;
     this.count = 0;
-    this.offset = 10; // skip ids "1" through "9"
-    this.msb = 35;
-    this.power = 1;
+    this.offset = 374;
+    this.msb = 1295;
+    this.power = 2;
   }
 
   next() {

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -9,17 +9,17 @@ test("StyletronServer toCss", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.c{color:green}.d:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}",
   );
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.c{color:green}.d:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}",
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getCss(),
-    ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.c{color:green}.d:hover{color:green}}@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}",
+    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
   );
   t.end();
 });
@@ -35,11 +35,11 @@ test("StyletronServer getStylesheets", t => {
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
     {
-      css: ".c{color:green}.d:hover{color:green}",
+      css: ".ag{color:green}.ah:hover{color:green}",
       attrs: {media: "(max-width: 800px)"},
     },
   ]);
@@ -47,35 +47,35 @@ test("StyletronServer getStylesheets", t => {
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
     {
-      css: ".c{color:green}.d:hover{color:green}",
+      css: ".ag{color:green}.ah:hover{color:green}",
       attrs: {media: "(max-width: 800px)"},
     },
     {
-      css: "@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}",
+      css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
   ]);
   injectFixtureFontFace(styletron);
   t.deepEqual(styletron.getStylesheets(), [
     {
-      css: "@font-face{font-family:a;src:local('Roboto')}",
+      css: "@font-face{font-family:ae;src:local('Roboto')}",
       attrs: {"data-hydrate": "font-face"},
     },
     {
       css:
-        ".a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
     {
-      css: ".c{color:green}.d:hover{color:green}",
+      css: ".ag{color:green}.ah:hover{color:green}",
       attrs: {media: "(max-width: 800px)"},
     },
     {
-      css: "@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}",
+      css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
   ]);
@@ -93,35 +93,35 @@ test("StyletronServer getStylesheetsHtml ", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.c{color:green}.d:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style>',
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.c{color:green}.d:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   injectFixtureFontFace(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:a;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.a{color:red}.b{color:green}.e:hover{display:none}.f{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.g{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.c{color:green}.d:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   t.end();
 });
 
 test("StyletronServer prefix option", t => {
   const styletron = new Styletron({prefix: "foo_"});
-  t.equal(styletron.renderStyle({color: "red"}), "foo_a");
-  t.equal(injectFixtureFontFace(styletron), "foo_a");
-  t.equal(injectFixtureKeyframes(styletron), "foo_a");
+  t.equal(styletron.renderStyle({color: "red"}), "foo_ae");
+  t.equal(injectFixtureFontFace(styletron), "foo_ae");
+  t.equal(injectFixtureKeyframes(styletron), "foo_ae");
   t.deepEqual(styletron.getStylesheets(), [
     {
-      css: "@font-face{font-family:foo_a;src:local('Roboto')}",
+      css: "@font-face{font-family:foo_ae;src:local('Roboto')}",
       attrs: {"data-hydrate": "font-face"},
     },
-    {css: ".foo_a{color:red}", attrs: {}},
+    {css: ".foo_ae{color:red}", attrs: {}},
     {
       css:
-        "@keyframes foo_a{from{color:purple}50%{color:yellow}to{color:orange}}",
+        "@keyframes foo_ae{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
   ]);


### PR DESCRIPTION
Start sequential atomic identifiers from "ae" an on to avoid producing "ad" which can be blocked by ad blockers.

Fixes https://github.com/rtsao/styletron/issues/139