### PR TITLE
Annotate styletron-engine-atomic/src/client.js with @flow 

### DIFF
--- a/packages/styletron-engine-atomic/src/client/client.js
+++ b/packages/styletron-engine-atomic/src/client/client.js
@@ -1,3 +1,5 @@
+// @flow
+
 /* eslint-env browser */
 
 const STYLES_HYDRATOR = /\.([^{:]+)(:[^{]+)?{(?:[^}]*;)?([^}]*?)}/g;


### PR DESCRIPTION
Ensures that to ensure types can be used in consumers.  Without this, consumer code may be uncovered.

Example without `// @flow` annotation from [`fusion-plugin-styletron-react`](https://github.com/fusionjs/fusion-plugin-styletron-react/blob/master/src/browser.js):

<img width="670" alt="screen shot 2018-04-04 at 3 25 34 pm" src="https://user-images.githubusercontent.com/3497835/38337994-833c87b6-381c-11e8-8428-8631c37710b9.png">