### PR TITLE
Debug classes w/ source map to JS location

### DIFF
--- a/packages/styletron-react-core/package.json
+++ b/packages/styletron-react-core/package.json
@@ -31,7 +31,9 @@
   },
   "dependencies": {
     "create-react-context": "^0.2.2",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "sourcemap-codec": "^1.4.1",
+    "stacktrace-js": "^2.0.0"
   },
   "peerDependencies": {
     "react": "0.14.x - 16.x"

--- a/packages/styletron-react-core/src/dev-tool.js
+++ b/packages/styletron-react-core/src/dev-tool.js
@@ -11,6 +11,28 @@ const schedule = window.requestIdleCallback
 
 let counter = 0;
 let queue = [];
+let debugEnabled = false;
+
+export function enableDebug() {
+  debugEnabled = true;
+}
+
+export function addDebugClass(baseStyletron, stackIndex) {
+  if (!debugEnabled) {
+    return;
+  }
+  const {className, selector} = getUniqueId();
+  baseStyletron.debugClass = className;
+
+  const trace = getTrace();
+
+  trace
+    .then(stackframes => {
+      const {fileName, lineNumber} = stackframes[stackIndex];
+      addToQueue({selector, lineNumber, fileName});
+    })
+    .catch(err => console.log(err)); // eslint-disable-line no-console
+}
 
 function flush() {
   const {rules, segments, sources} = queue.reduce(
@@ -52,20 +74,6 @@ function addToQueue(item) {
   if (prevCount === 0) {
     schedule(flush);
   }
-}
-
-export function addDebugClass(baseStyletron, stackIndex) {
-  const {className, selector} = getUniqueId();
-  baseStyletron.debugClass = className;
-
-  const trace = getTrace();
-
-  trace
-    .then(stackframes => {
-      const {fileName, lineNumber} = stackframes[stackIndex];
-      addToQueue({selector, lineNumber, fileName});
-    })
-    .catch(err => console.log(err)); // eslint-disable-line no-console
 }
 
 function getTrace() {

--- a/packages/styletron-react-core/src/dev-tool.js
+++ b/packages/styletron-react-core/src/dev-tool.js
@@ -1,0 +1,82 @@
+/* eslint-env browser */
+
+import StackTrace from "stacktrace-js";
+import {encode} from "sourcemap-codec";
+
+const cache = {};
+
+const schedule = window.requestIdleCallback
+  ? task => window.requestIdleCallback(task, {timeout: 180})
+  : window.requestAnimationFrame;
+
+let counter = 0;
+let queue = [];
+
+function flush() {
+  const {rules, segments, sources} = queue.reduce(
+    (acc, {selector, lineNumber, fileName}) => {
+      let sourceIndex = acc.sources.indexOf(fileName);
+      if (sourceIndex === -1) {
+        sourceIndex = acc.sources.push(fileName) - 1;
+      }
+      acc.rules.push(`${selector} {}`);
+      acc.segments.push([[0, sourceIndex, lineNumber - 1, 0]]);
+      return acc;
+    },
+    {rules: [], segments: [], sources: []},
+  );
+  queue = [];
+
+  const mappings = encode(segments);
+  const map = {
+    version: 3,
+    sources,
+    mappings,
+    sourcesContent: sources.map(source => cache[source]),
+  };
+
+  const json = JSON.stringify(map);
+  const base64 = window.btoa(json);
+
+  const css =
+    rules.join("\n") +
+    `\n\/*# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64} */`;
+  const style = document.createElement("style");
+  style.appendChild(document.createTextNode(css));
+  document.head.appendChild(style);
+}
+
+function addToQueue(item) {
+  const prevCount = queue.length;
+  queue.push(item);
+  if (prevCount === 0) {
+    schedule(flush);
+  }
+}
+
+export function addDebugClass(baseStyletron, stackIndex) {
+  const {className, selector} = getUniqueId();
+  baseStyletron.debugClass = className;
+
+  const trace = getTrace();
+
+  trace
+    .then(stackframes => {
+      const {fileName, lineNumber} = stackframes[stackIndex];
+      addToQueue({selector, lineNumber, fileName});
+    })
+    .catch(err => console.log(err)); // eslint-disable-line no-console
+}
+
+function getTrace() {
+  return StackTrace.get({sourceCache: cache});
+}
+
+function getUniqueId() {
+  const id = counter++;
+  const className = `__debug_${id}`;
+  return {
+    selector: `.${className}`,
+    className,
+  };
+}

--- a/packages/styletron-react-core/src/index.js
+++ b/packages/styletron-react-core/src/index.js
@@ -15,6 +15,8 @@ import createReactContext, {type Context} from "create-react-context";
 
 import {addDebugClass} from "./dev-tool.js";
 
+export {enableDebug} from "./dev-tool.js";
+
 const StyletronContext: Context<any> = createReactContext();
 
 export const Provider = StyletronContext.Provider;
@@ -499,5 +501,3 @@ export function assign<Style: Object>(target: Style, source: Style): Style {
   }
   return target;
 }
-
-export function noop() {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,12 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.1.tgz#a3202b8fb03114aa9b40a0e3669e48b2b65a010a"
+  dependencies:
+    stackframe "^1.0.3"
+
 es-abstract@^1.5.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
@@ -4738,6 +4744,10 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4751,6 +4761,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
 source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+sourcemap-codec@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -4801,6 +4815,31 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-generator@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.2.tgz#3c13d952a596ab9318fec0669d0a1df8b87176c7"
+  dependencies:
+    stackframe "^1.0.4"
+
+stackframe@^1.0.3, stackframe@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+
+stacktrace-gps@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.0.4"
+
+stacktrace-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
+  dependencies:
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
In development, add a unique debug class name to elements rendered by a given styled component. This debug class name has no styles but a generated sourcemap to JS location. This sourcemap is generated dynamically by capturing a stack trace, no build-time plugins are needed.

This makes it easier to map from a DOM element to the styled component using the DOM inspector.

**Demo**

<img src="https://user-images.githubusercontent.com/780408/39457018-ac42410e-4c9f-11e8-91e7-ac2da8bfe230.gif" width="400px">
