### PR TITLE
Add workaround for crossorigin web workers

### DIFF
--- a/packages/styletron-react-core/src/dev-tool.js
+++ b/packages/styletron-react-core/src/dev-tool.js
@@ -10,9 +10,13 @@ export function addDebugMetadata(instance, stackIndex) {
 export class DebugEngine {
   constructor(worker) {
     if (!worker) {
-      worker = new Worker(
-        "https://unpkg.com/css-to-js-sourcemap-worker@2.0.1/worker.js",
+      const workerBlob = new Blob(
+        [
+          `importScripts("https://unpkg.com/css-to-js-sourcemap-worker@2.0.1/worker.js")`,
+        ],
+        {type: "application/javascript"},
       );
+      worker = new Worker(URL.createObjectURL(workerBlob));
       worker.postMessage({
         id: "init_wasm",
         url: "https://unpkg.com/css-to-js-sourcemap-worker@2.0.1/mappings.wasm",


### PR DESCRIPTION
Apparently cross origin web workers are always disallowed. But this workaround seems to do the trick (as long as the `worker-src` CSP header is compatible).